### PR TITLE
scripts, update-json: fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,20 +17,25 @@ The wizard produces Linux disk images based on NixOS. NixOS allows configuration
 - With Nix: `nix develop`
 - With [direnv](https://direnv.net/): `direnv allow`
 
-4. **Install Dependencies and Build**
+4. **Fetch Module Options**
+  ```
+  , schema
+  ```
+
+5. **Install Dependencies and Build**
   ```
   yarn install && yarn build
   ```
 
-5. **Start the Web UI**
+6. **Start the Web UI**
   ```
   , server
   ```
 
-6. **Open a Command Runner** (optional)
+7. **Open a Command Runner** (optional)
   ```
   tail -f pipe | sh
   ```
   The front end runs its commands through this; leave it open for functionality.
 
-7. **Check it out:** [http://localhost:8081](http://localhost:8081)
+8. **Check it out:** [http://localhost:8081](http://localhost:8081)

--- a/flake.nix
+++ b/flake.nix
@@ -184,7 +184,7 @@
               hostnames)
           );
 
-        schema = nixobolus.outputs.exports.homestakeros;
+        schema = nixobolus.outputs.exports;
       };
     };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -104,7 +104,7 @@
           };
           update-json = {
             type = "app";
-            program = "${self.packages.${system}.init-ssv}/bin/update-json";
+            program = "${self.packages.${system}.update-json}/bin/update-json";
           };
         };
 

--- a/flake.nix
+++ b/flake.nix
@@ -66,7 +66,7 @@
           server = {
             description = "Initialize and launch the web server";
             exec = ''
-              && nix run .#update-json \
+              nix run --no-warn-dirty .#update-json \
               && nix run .#
             '';
             category = "Essentials";

--- a/flake.nix
+++ b/flake.nix
@@ -66,7 +66,6 @@
           server = {
             description = "Initialize and launch the web server";
             exec = ''
-              nix eval --json .#schema | jq > webui/public/schema.json \
               && nix run .#update-json \
               && nix run .#
             '';


### PR DESCRIPTION
The script was assuming that some of the paths exist, even though this is one of the first things to be run.

Fixed that, and the script also creates the `webui/nixosConfiguration/hostname.json` file with an empty JSON array if no hostnames are found with `nix eval`.
