### PR TITLE
mission-control: merge init commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,25 +17,15 @@ The wizard produces Linux disk images based on NixOS. NixOS allows configuration
 - With Nix: `nix develop`
 - With [direnv](https://direnv.net/): `direnv allow`
 
-4. **Fetch Module Options**
-  ```
-  , schema
-  ```
-
-5. **Install Dependencies and Build**
-  ```
-  yarn install && yarn build
-  ```
-
-6. **Start the Web UI**
+4. **Start the Web UI**
   ```
   , server
   ```
 
-7. **Open a Command Runner** (optional)
+5. **Open a Command Runner** (optional)
   ```
   tail -f pipe | sh
   ```
   The front end runs its commands through this; leave it open for functionality.
 
-8. **Check it out:** [http://localhost:8081](http://localhost:8081)
+6. **Check it out:** [http://localhost:8081](http://localhost:8081)

--- a/flake.nix
+++ b/flake.nix
@@ -56,13 +56,6 @@
         formatter = nixpkgs.legacyPackages.${system}.alejandra;
 
         mission-control.scripts = {
-          schema = {
-            description = "Update schema using current version of nixobolus";
-            exec = ''
-              nix eval --json .#schema | jq > webui/public/schema.json
-            '';
-            category = "Development Tools";
-          };
           server = {
             description = "Initialize and launch the web server";
             exec = ''

--- a/flake.nix
+++ b/flake.nix
@@ -66,8 +66,10 @@
           server = {
             description = "Initialize and launch the web server";
             exec = ''
-              nix run --no-warn-dirty .#update-json \
-              && nix run .#
+              nix eval --no-warn-dirty --json .#schema | jq > webui/public/schema.json \
+              && yarn install && yarn build \
+              && nix run --no-warn-dirty .#update-json \
+              && nix run --no-warn-dirty .#
             '';
             category = "Essentials";
           };


### PR DESCRIPTION
Combined the `, schema` and `, server` mission-control commands into one, allowing the server to be initialized using only a single command. This could also be achieved by resolving issues in https://github.com/ponkila/HomestakerOS/pull/20 and merging it, but I think this is acceptable for the time being since we need to demo this soon.