### PR TITLE
feat: systems and formats

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -147,38 +147,63 @@
 
       flake = let
         inherit (self) outputs;
-        system = "x86_64-linux";
       in {
         nixosConfigurations = let
+          # Fetch hostnames from nixosConfigurations directory
           ls = builtins.readDir ./nixosConfigurations;
           hostnames =
             builtins.filter
             (name: builtins.hasAttr name ls && (ls.${name} == "directory"))
             (builtins.attrNames ls);
+
+          # Define available system architectures and formats
+          formats = ["kexecTree" "isoImage"];
+          systems = ["x86_64-linux" "aarch64-linux"];
+
+          # Generate list of attribute sets for each possible host
+          hosts = builtins.concatMap (hostname:
+            builtins.concatMap (format:
+              builtins.map (system: {
+                name = hostname;
+                format = format;
+                system = system;
+              })
+              systems)
+            formats)
+          hostnames;
         in
           nixpkgs.lib.mkIf (
             builtins.pathExists ./nixosConfigurations
           ) (
-            builtins.listToAttrs (map (hostname: {
-                name = hostname;
+            builtins.listToAttrs (map (host: {
+                name = "${host.name}-${host.system}-${host.format}";
                 value = nixpkgs.lib.nixosSystem {
-                  inherit system;
+                  system = host.system;
                   specialArgs = {inherit inputs outputs;};
-                  modules =
-                    [
-                      nixobolus.nixosModules.kexecTree
-                      nixobolus.nixosModules.homestakeros
-                      ./nixosConfigurations/${hostname}
-                      {
-                        system.stateVersion = "23.05";
+                  modules = [
+                    nixobolus.nixosModules.${host.format}
+                    nixobolus.nixosModules.homestakeros
+                    ./nixosConfigurations/${host.name}
+                    (
+                      if host.format == "isoImage"
+                      then
+                        {pkgs, ...}: {
+                          # Use stable kernel
+                          boot.kernelPackages = pkgs.linuxPackagesFor (pkgs.linux);
+                        }
+                      else {
                         # Bootloader for x86_64-linux / aarch64-linux
                         boot.loader.systemd-boot.enable = true;
                         boot.loader.efi.canTouchEfiVariables = true;
                       }
-                    ];
+                    )
+                    {
+                      system.stateVersion = "23.05";
+                    }
+                  ];
                 };
               })
-              hostnames)
+              hosts)
           );
 
         schema = nixobolus.outputs.exports.homestakeros;

--- a/scripts/update-json.sh
+++ b/scripts/update-json.sh
@@ -14,19 +14,30 @@ declare -a nix_flags=(
 # Make config directory if doesn't exist
 mkdir -p $config_dir
 
-# Fetch hostnames from 'flake.nix'
-mapfile -t hostnames < <(nix eval --json .#nixosConfigurations --apply builtins.attrNames | jq -r '.[]')
+# Fetch nixosConfiguration attribute names from 'flake.nix'
+mapfile -t attrNames < <(nix eval --json .#nixosConfigurations --apply builtins.attrNames | jq -r '.[]')
 
-if [ ${#hostnames[@]} -gt 0 ]; then
-    printf '%s\n' "${hostnames[@]}" | jq -R . | jq -s . > $config_dir/hostnames.json
+names=()
 
-    # Get and save the JSON data
-    for hostname in "${hostnames[@]}"; do
-      default_json="$config_dir/$hostname/default.json"
-      json_data=$(nix eval --json .#nixosConfigurations."$hostname".config.homestakeros "${nix_flags[@]}")
-      mkdir -p "$config_dir/$hostname"
-      echo "$json_data" | jq -r "." > "$default_json"
+if [ ${#attrNames[@]} -gt 0 ]; then
+    for attrName in "${attrNames[@]}"; do
+      # Extract the name part of the nixosConfiguration entry
+      name=$(echo "$attrName" | cut -d '-' -f1)
+
+      # Skip if the current name is the same as the previous one
+      if [[ "$name" == "${names[-1]}" ]]; then
+        continue
+      else
+        # Fetch and save the JSON data
+        default_json="$config_dir/$name/default.json"
+        json_data=$(nix eval --json .#nixosConfigurations."$attrName".config.homestakeros "${nix_flags[@]}")
+        mkdir -p "$config_dir/$name"
+        echo "$json_data" | jq -r "." > "$default_json"
+      fi
+      names+=("$name")
     done
+    # Save (host)names as JSON data
+    printf '%s\n' "${names[@]}" | jq -R . | jq -s . > $config_dir/hostnames.json
 else
     echo "[]" > $config_dir/hostnames.json
 fi


### PR DESCRIPTION
Added '--format' and '--system' flags to the buidl script.

This means that you can now build any combination of the supported formats and systems on command:
```shell
echo $json_data | nix run .#buidl -- -b homestakeros -n foobar -f isoImage -s aarch64-linux
```

This functionality works by generating `nixosConfigurations` attributes in the flake for every possible combination of these parameters for each configured host.

Attribute names are formatted as follows: 'name-system-format', for example:

```shell
[I] kari@torque ~/W/HomestakerOS (feat/format)> nix eval --json .#nixosConfigurations --apply builtins.attrNames --no-warn-dirty | jq -r '.[]'
foobar-aarch64-linux-isoImage
foobar-aarch64-linux-kexecTree
foobar-x86_64-linux-isoImage
foobar-x86_64-linux-kexecTree
```
Despite having multiple `nixosConfigurations` entries, the hosts will still only have one directory at `webui/public/nixosConfigurations` and `nixosConfigurations`. Options for these should be added manually on this PR, as they are unrelated to module options aka schema.




