### PR TITLE
feat: devenv

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,1 @@
-use flake
+use flake . --impure

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ result
 .direnv
 pipe
 private
+.devenv
+.pre-commit-config.yaml

--- a/README.md
+++ b/README.md
@@ -16,12 +16,12 @@ Check out the live demo at https://demo.homestakeros.com/
   ```
 
 3. **Set Up a Development Environment**
-- With Nix: `nix develop`
+- With Nix: `nix develop . --impure`
 - With [direnv](https://direnv.net/): `direnv allow`
 
 4. **Start the Web UI**
   ```
-  , server
+  server
   ```
 
 5. **Open a Command Runner**

--- a/devenv.yaml
+++ b/devenv.yaml
@@ -1,0 +1,4 @@
+allowUnfree: true
+inputs:
+  nixpkgs:
+    url: github:NixOS/nixpkgs/nixpkgs-unstable

--- a/devenv.yaml
+++ b/devenv.yaml
@@ -1,4 +1,0 @@
-allowUnfree: true
-inputs:
-  nixpkgs:
-    url: github:NixOS/nixpkgs/nixpkgs-unstable

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,26 @@
 {
   "nodes": {
+    "devenv": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "nix": "nix",
+        "nixpkgs": "nixpkgs",
+        "pre-commit-hooks": "pre-commit-hooks"
+      },
+      "locked": {
+        "lastModified": 1695635472,
+        "narHash": "sha256-+0lqQZmbzdglPh8JoMAZzP1XXanhBg9BcbjVXnwEC5E=",
+        "owner": "cachix",
+        "repo": "devenv",
+        "rev": "42a26aa1b2265cf505df056e040e2b1ef8073b76",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "devenv",
+        "type": "github"
+      }
+    },
     "devshell": {
       "inputs": {
         "nixpkgs": [
@@ -7,7 +28,7 @@
           "ethereum-nix",
           "nixpkgs"
         ],
-        "systems": "systems"
+        "systems": "systems_2"
       },
       "locked": {
         "lastModified": 1688380630,
@@ -26,7 +47,7 @@
     "ethereum-nix": {
       "inputs": {
         "devshell": "devshell",
-        "flake-compat": "flake-compat",
+        "flake-compat": "flake-compat_2",
         "flake-parts": "flake-parts_2",
         "flake-root": "flake-root_2",
         "foundry-nix": "foundry-nix",
@@ -53,6 +74,22 @@
       }
     },
     "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1673956053,
+        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_2": {
       "locked": {
         "lastModified": 1688025799,
         "narHash": "sha256-ktpB4dRtnksm9F5WawoIkEneh1nrEvuxb5lJFt1iOyw=",
@@ -212,6 +249,24 @@
       }
     },
     "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1685518550,
+        "narHash": "sha256-o2d0KcvaXzTrPRIo0kOLV0/QXHhDQ5DTi+OxcjO8xqY=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "a1720a10a6cfe8234c0e93907ffe81be440f4cef",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
       "locked": {
         "lastModified": 1644229661,
         "narHash": "sha256-1YdnJAsNy69bpcjuoKdOYQX0YxZBiCYZo4Twxerqv7k=",
@@ -226,7 +281,7 @@
         "type": "github"
       }
     },
-    "flake-utils_2": {
+    "flake-utils_3": {
       "locked": {
         "lastModified": 1667077288,
         "narHash": "sha256-bdC8sFNDpT0HK74u9fUkpbf1MEzVYJ+ka7NXCdgBoaA=",
@@ -243,7 +298,7 @@
     },
     "foundry-nix": {
       "inputs": {
-        "flake-utils": "flake-utils",
+        "flake-utils": "flake-utils_2",
         "nixpkgs": [
           "nixobolus",
           "ethereum-nix",
@@ -262,6 +317,28 @@
         "owner": "shazow",
         "ref": "monthly",
         "repo": "foundry.nix",
+        "type": "github"
+      }
+    },
+    "gitignore": {
+      "inputs": {
+        "nixpkgs": [
+          "devenv",
+          "pre-commit-hooks",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1660459072,
+        "narHash": "sha256-8DFJjXG8zqoONA1vXtgeKXy68KdJL5UaXR8NtVMUbx8=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "a20de23b925fd8264fd7fad6454652e142fd7f73",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
         "type": "github"
       }
     },
@@ -285,7 +362,7 @@
       "inputs": {
         "flake-parts": "flake-parts_4",
         "haskell-flake": "haskell-flake",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs_2"
       },
       "locked": {
         "lastModified": 1688568579,
@@ -304,7 +381,7 @@
       "inputs": {
         "flake-parts": "flake-parts_3",
         "hercules-ci-agent": "hercules-ci-agent",
-        "nixpkgs": "nixpkgs_2"
+        "nixpkgs": "nixpkgs_3"
       },
       "locked": {
         "lastModified": 1689397210,
@@ -317,6 +394,22 @@
       "original": {
         "owner": "hercules-ci",
         "repo": "hercules-ci-effects",
+        "type": "github"
+      }
+    },
+    "lowdown-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1633514407,
+        "narHash": "sha256-Dw32tiMjdK9t3ETl5fzGrutQTzh2rufgZV4A/BbxuD4=",
+        "owner": "kristapsdz",
+        "repo": "lowdown",
+        "rev": "d2c2b44ff6c27b936ec27358a2653caaef8f73b8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "kristapsdz",
+        "repo": "lowdown",
         "type": "github"
       }
     },
@@ -335,18 +428,27 @@
         "type": "github"
       }
     },
-    "mission-control_2": {
+    "nix": {
+      "inputs": {
+        "lowdown-src": "lowdown-src",
+        "nixpkgs": [
+          "devenv",
+          "nixpkgs"
+        ],
+        "nixpkgs-regression": "nixpkgs-regression"
+      },
       "locked": {
-        "lastModified": 1690573269,
-        "narHash": "sha256-9NSmHRQvzBzfuKD3zHE2fM5xPa+hHSy7xcWQqZaCjFw=",
-        "owner": "Platonic-Systems",
-        "repo": "mission-control",
-        "rev": "9d25d9f8d610916fc144f6afc1f064392fbeec1c",
+        "lastModified": 1676545802,
+        "narHash": "sha256-EK4rZ+Hd5hsvXnzSzk2ikhStJnD63odF7SzsQ8CuSPU=",
+        "owner": "domenkozar",
+        "repo": "nix",
+        "rev": "7c91803598ffbcfe4a55c44ac6d49b2cf07a527f",
         "type": "github"
       },
       "original": {
-        "owner": "Platonic-Systems",
-        "repo": "mission-control",
+        "owner": "domenkozar",
+        "ref": "relaxed-flakes",
+        "repo": "nix",
         "type": "github"
       }
     },
@@ -355,9 +457,9 @@
         "ethereum-nix": "ethereum-nix",
         "flake-parts": "flake-parts_5",
         "flake-root": "flake-root_3",
-        "mission-control": "mission-control_2",
-        "nixpkgs": "nixpkgs_3",
-        "nixpkgs-stable": "nixpkgs-stable",
+        "mission-control": "mission-control",
+        "nixpkgs": "nixpkgs_4",
+        "nixpkgs-stable": "nixpkgs-stable_2",
         "pre-commit-hooks-nix": "pre-commit-hooks-nix"
       },
       "locked": {
@@ -376,16 +478,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1688322751,
-        "narHash": "sha256-eW62dC5f33oKZL7VWlomttbUnOTHrAbte9yNUNW8rbk=",
+        "lastModified": 1678875422,
+        "narHash": "sha256-T3o6NcQPwXjxJMn2shz86Chch4ljXgZn746c2caGxd8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0fbe93c5a7cac99f90b60bdf5f149383daaa615f",
+        "rev": "126f49a01de5b7e35a43fd43f891ecf6d3a51459",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-unstable",
+        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -444,7 +546,39 @@
         "type": "github"
       }
     },
+    "nixpkgs-regression": {
+      "locked": {
+        "lastModified": 1643052045,
+        "narHash": "sha256-uGJ0VXIhWKGXxkeNnq4TvV3CIOkUJ3PAoLZ3HMzNVMw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
+        "type": "github"
+      }
+    },
     "nixpkgs-stable": {
+      "locked": {
+        "lastModified": 1685801374,
+        "narHash": "sha256-otaSUoFEMM+LjBI1XL/xGB5ao6IwnZOXc47qhIgJe8U=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "c37ca420157f4abc31e26f436c1145f8951ff373",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-23.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-stable_2": {
       "locked": {
         "lastModified": 1692207601,
         "narHash": "sha256-tfPGNKQcJT1cvT6ufqO/7ydYNL6mcJClvzbrzhKjB80=",
@@ -478,6 +612,22 @@
     },
     "nixpkgs_2": {
       "locked": {
+        "lastModified": 1688322751,
+        "narHash": "sha256-eW62dC5f33oKZL7VWlomttbUnOTHrAbte9yNUNW8rbk=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "0fbe93c5a7cac99f90b60bdf5f149383daaa615f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_3": {
+      "locked": {
         "lastModified": 1689393711,
         "narHash": "sha256-l3gyTPy/qWLDk1CY1EgYwlsxcGxN2aVd7MlCzQa69rk=",
         "owner": "NixOS",
@@ -491,7 +641,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_3": {
+    "nixpkgs_4": {
       "locked": {
         "lastModified": 1692174805,
         "narHash": "sha256-xmNPFDi/AUMIxwgOH/IVom55Dks34u1g7sFKKebxUm0=",
@@ -507,7 +657,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_4": {
+    "nixpkgs_5": {
       "locked": {
         "lastModified": 1667292599,
         "narHash": "sha256-7ISOUI1aj6UKMPIL+wwthENL22L3+A9V+jS8Is3QsRo=",
@@ -521,7 +671,7 @@
         "type": "indirect"
       }
     },
-    "nixpkgs_5": {
+    "nixpkgs_6": {
       "locked": {
         "lastModified": 1692447944,
         "narHash": "sha256-fkJGNjEmTPvqBs215EQU4r9ivecV5Qge5cF/QDLVn3U=",
@@ -537,10 +687,38 @@
         "type": "github"
       }
     },
+    "pre-commit-hooks": {
+      "inputs": {
+        "flake-compat": [
+          "devenv",
+          "flake-compat"
+        ],
+        "flake-utils": "flake-utils",
+        "gitignore": "gitignore",
+        "nixpkgs": [
+          "devenv",
+          "nixpkgs"
+        ],
+        "nixpkgs-stable": "nixpkgs-stable"
+      },
+      "locked": {
+        "lastModified": 1688056373,
+        "narHash": "sha256-2+SDlNRTKsgo3LBRiMUcoEUb6sDViRNQhzJquZ4koOI=",
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "rev": "5843cf069272d92b60c3ed9e55b7a8989c01d4c7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "type": "github"
+      }
+    },
     "pre-commit-hooks-nix": {
       "inputs": {
-        "flake-utils": "flake-utils_2",
-        "nixpkgs": "nixpkgs_4"
+        "flake-utils": "flake-utils_3",
+        "nixpkgs": "nixpkgs_5"
       },
       "locked": {
         "lastModified": 1667612001,
@@ -559,14 +737,29 @@
     },
     "root": {
       "inputs": {
+        "devenv": "devenv",
         "flake-parts": "flake-parts",
         "flake-root": "flake-root",
-        "mission-control": "mission-control",
         "nixobolus": "nixobolus",
-        "nixpkgs": "nixpkgs_5"
+        "nixpkgs": "nixpkgs_6"
       }
     },
     "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",

--- a/flake.lock
+++ b/flake.lock
@@ -49,7 +49,7 @@
         "devshell": "devshell",
         "flake-compat": "flake-compat_2",
         "flake-parts": "flake-parts_2",
-        "flake-root": "flake-root_2",
+        "flake-root": "flake-root",
         "foundry-nix": "foundry-nix",
         "hercules-ci-effects": "hercules-ci-effects",
         "nixpkgs": [
@@ -219,21 +219,6 @@
       }
     },
     "flake-root_2": {
-      "locked": {
-        "lastModified": 1680964220,
-        "narHash": "sha256-dIdTYcf+KW9a4pKHsEbddvLVSfR1yiAJynzg2x0nfWg=",
-        "owner": "srid",
-        "repo": "flake-root",
-        "rev": "f1c0b93d05bdbea6c011136ba1a135c80c5b326c",
-        "type": "github"
-      },
-      "original": {
-        "owner": "srid",
-        "repo": "flake-root",
-        "type": "github"
-      }
-    },
-    "flake-root_3": {
       "locked": {
         "lastModified": 1680964220,
         "narHash": "sha256-dIdTYcf+KW9a4pKHsEbddvLVSfR1yiAJynzg2x0nfWg=",
@@ -456,7 +441,7 @@
       "inputs": {
         "ethereum-nix": "ethereum-nix",
         "flake-parts": "flake-parts_5",
-        "flake-root": "flake-root_3",
+        "flake-root": "flake-root_2",
         "mission-control": "mission-control",
         "nixpkgs": "nixpkgs_4",
         "nixpkgs-stable": "nixpkgs-stable_2",
@@ -739,7 +724,6 @@
       "inputs": {
         "devenv": "devenv",
         "flake-parts": "flake-parts",
-        "flake-root": "flake-root",
         "nixobolus": "nixobolus",
         "nixpkgs": "nixpkgs_6"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,6 @@
   inputs = {
     devenv.url = "github:cachix/devenv";
     flake-parts.url = "github:hercules-ci/flake-parts";
-    flake-root.url = "github:srid/flake-root";
     nixobolus.url = "github:ponkila/nixobolus";
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
   };
@@ -23,7 +22,6 @@
       ];
       imports = [
         inputs.devenv.flakeModule
-        inputs.flake-root.flakeModule
       ];
 
       perSystem = {

--- a/flake.nix
+++ b/flake.nix
@@ -1,8 +1,8 @@
 {
   inputs = {
+    devenv.url = "github:cachix/devenv";
     flake-parts.url = "github:hercules-ci/flake-parts";
     flake-root.url = "github:srid/flake-root";
-    mission-control.url = "github:Platonic-Systems/mission-control";
     nixobolus.url = "github:ponkila/nixobolus";
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
   };
@@ -22,14 +22,15 @@
         "x86_64-linux"
       ];
       imports = [
+        inputs.devenv.flakeModule
         inputs.flake-root.flakeModule
-        inputs.mission-control.flakeModule
       ];
 
       perSystem = {
         pkgs,
         lib,
         config,
+        self',
         inputs',
         system,
         ...
@@ -55,31 +56,46 @@
       in rec {
         formatter = nixpkgs.legacyPackages.${system}.alejandra;
 
-        mission-control.scripts = {
-          server = {
-            description = "Initialize and launch the web server";
-            exec = ''
-              nix eval --no-warn-dirty --json .#schema | jq > webui/public/schema.json \
-              && yarn install && yarn build \
-              && nix run --no-warn-dirty .#update-json \
-              && nix run --no-warn-dirty .#
-            '';
-            category = "Essentials";
-          };
-        };
-
-        devShells = {
-          default = pkgs.mkShell {
-            nativeBuildInputs = with pkgs; [
+        devenv.shells = {
+          default = {
+            packages = with pkgs; [
+              self'.packages.init-ssv
               nodejs
               jq
               yarn
               yarn2nix
             ];
-            inputsFrom = [
-              config.flake-root.devShell
-              config.mission-control.devShell
-            ];
+            scripts.server.exec = ''
+              nix eval --no-warn-dirty --json .#schema | jq > webui/public/schema.json \
+              && yarn install && yarn build \
+              && nix run --no-warn-dirty .#update-json \
+              && nix run --no-warn-dirty .#
+            '';
+            env = {
+              NIX_CONFIG = ''
+                accept-flake-config = true
+                extra-experimental-features = flakes nix-command
+                warn-dirty = false
+              '';
+            };
+            enterShell = ''
+              cat <<INFO
+
+              ### HomestakerOS ###
+
+              Available commands:
+
+                server    : Initialize and launch the web server
+                init-ssv  : Generate an SSV operator key pair
+
+              INFO
+            '';
+            pre-commit.hooks = {
+              alejandra.enable = true;
+              shellcheck.enable = true;
+            };
+            # Workaround for https://github.com/cachix/devenv/issues/760
+            containers = pkgs.lib.mkForce {};
           };
         };
 
@@ -164,18 +180,17 @@
                 value = nixpkgs.lib.nixosSystem {
                   inherit system;
                   specialArgs = {inherit inputs outputs;};
-                  modules =
-                    [
-                      nixobolus.nixosModules.kexecTree
-                      nixobolus.nixosModules.homestakeros
-                      ./nixosConfigurations/${hostname}
-                      {
-                        system.stateVersion = "23.05";
-                        # Bootloader for x86_64-linux / aarch64-linux
-                        boot.loader.systemd-boot.enable = true;
-                        boot.loader.efi.canTouchEfiVariables = true;
-                      }
-                    ];
+                  modules = [
+                    nixobolus.nixosModules.kexecTree
+                    nixobolus.nixosModules.homestakeros
+                    ./nixosConfigurations/${hostname}
+                    {
+                      system.stateVersion = "23.05";
+                      # Bootloader for x86_64-linux / aarch64-linux
+                      boot.loader.systemd-boot.enable = true;
+                      boot.loader.efi.canTouchEfiVariables = true;
+                    }
+                  ];
                 };
               })
               hostnames)

--- a/scripts/init-ssv.sh
+++ b/scripts/init-ssv.sh
@@ -3,7 +3,7 @@
 
 # Check arguments
 if [ "$#" -ne 1 ]; then
-    echo "Usage: nix run .#init-ssv -- <hostname>"
+    echo "Usage: init-ssv <hostname>"
     exit 1
 fi
 


### PR DESCRIPTION
Switching from mission-control and devshell to [devenv](https://devenv.sh/guides/using-with-flake-parts/).

The project is now **impure**, so commands like `flake check` require the `--impure` flag.

As the devenv documentation states:

> **Why do I need** `--impure`?
>
> When working with flakes, pure mode prevents `devenv` from accessing and modifying its state data. Certain features, such as running processes with `devenv up`, won't function in pure mode.
