### PR TITLE
homestakeros, options: extra options

### DIFF
--- a/nixosModules/homestakeros/default.nix
+++ b/nixosModules/homestakeros/default.nix
@@ -318,7 +318,7 @@ in
           # ws for ssv
           "--ws"
         ]
-        ++ lib.optional (cfg.execution.erigon.extraOptions != null) cfg.execution.erigon.extraOptions;
+        ++ (if cfg.execution.erigon.extraOptions != null then cfg.execution.erigon.extraOptions else [ ]);
         allowedPorts = [ 30303 30304 42069 ];
       in
       createService serviceName serviceType execStart parsedEndpoint allowedPorts
@@ -360,7 +360,7 @@ in
           "--ws.port=8545"
           "--ws"
         ]
-        ++ lib.optional (cfg.execution.geth.extraOptions != null) cfg.execution.geth.extraOptions;
+        ++ (if cfg.execution.geth.extraOptions != null then cfg.execution.geth.extraOptions else [ ]);
         allowedPorts = [ 30303 ];
       in
       createService serviceName serviceType execStart parsedEndpoint allowedPorts
@@ -396,7 +396,7 @@ in
           "--Init.WebSocketsEnabled true"
           "--JsonRpc.WebSocketsPort 8545"
         ]
-        ++ lib.optional (cfg.execution.nethermind.extraOptions != null) cfg.execution.nethermind.extraOptions;
+        ++ (if cfg.execution.nethermind.extraOptions != null then cfg.execution.nethermind.extraOptions else [ ]);
         allowedPorts = [ 30303 ];
       in
       createService serviceName serviceType execStart parsedEndpoint allowedPorts
@@ -439,7 +439,7 @@ in
           "--rpc-ws-host=${parsedEndpoint.addr}"
           "--rpc-ws-port=8546"
         ]
-        ++ lib.optional (cfg.execution.besu.extraOptions != null) cfg.execution.besu.extraOptions;
+        ++ (if cfg.execution.besu.extraOptions != null then cfg.execution.besu.extraOptions else [ ]);
         allowedPorts = [ 30303 ];
       in
       createService serviceName serviceType execStart parsedEndpoint allowedPorts
@@ -468,7 +468,7 @@ in
             ]}"
           "-addr ${parsedEndpoint.addr}:${parsedEndpoint.port}"
         ]
-        ++ lib.optional (cfg.addons.mev-boost.extraOptions != null) cfg.addons.mev-boost.extraOptions;
+        ++ (if cfg.addons.mev-boost.extraOptions != null then cfg.addons.mev-boost.extraOptions else [ ]);
         allowedPorts = [ ];
       in
       createService serviceName serviceType execStart parsedEndpoint allowedPorts
@@ -502,11 +502,11 @@ in
             if cfg.consensus.lighthouse.slasher.enable
             then
               "--slasher \\\n\t"
-              + "--slasher-history-length "
-              + (toString cfg.consensus.lighthouse.slasher.historyLength)
-              + " \\\n\t"
-              + "--slasher-max-db-size "
-              + (toString cfg.consensus.lighthouse.slasher.maxDatabaseSize)
+                + "--slasher-history-length "
+                + (toString cfg.consensus.lighthouse.slasher.historyLength)
+                + " \\\n\t"
+                + "--slasher-max-db-size "
+                + (toString cfg.consensus.lighthouse.slasher.maxDatabaseSize)
             else ""
           )
           (
@@ -517,7 +517,7 @@ in
           "--metrics"
           "--checkpoint-sync-url \"https://beaconstate.info\""
         ]
-        ++ lib.optional (cfg.consensus.lighthouse.extraOptions != null) cfg.consensus.lighthouse.extraOptions;
+        ++ (if cfg.consensus.lighthouse.extraOptions != null then cfg.consensus.lighthouse.extraOptions else [ ]);
         allowedPorts = [ 9000 9001 ];
       in
       createService serviceName serviceType execStart parsedEndpoint allowedPorts
@@ -553,14 +553,14 @@ in
             if cfg.consensus.prysm.slasher.enable
             then
               "--historical-slasher-node \\\n\t"
-              + "--slasher-datadir ${cfg.consensus.prysm.dataDir}/beacon/slasher_db"
+                + "--slasher-datadir ${cfg.consensus.prysm.dataDir}/beacon/slasher_db"
             else ""
           )
           "--accept-terms-of-use"
           "--checkpoint-sync-url=https://beaconstate.info"
           "--genesis-beacon-api-url=https://beaconstate.info"
         ]
-        ++ lib.optional (cfg.consensus.prysm.extraOptions != null) cfg.consensus.prysm.extraOptions;
+        ++ (if cfg.consensus.prysm.extraOptions != null then cfg.consensus.prysm.extraOptions else [ ]);
         allowedPorts = [ 9000 ];
       in
       createService serviceName serviceType execStart parsedEndpoint allowedPorts
@@ -595,7 +595,7 @@ in
           )
           "--metrics-enabled=true"
         ]
-        ++ lib.optional (cfg.consensus.teku.extraOptions != null) cfg.consensus.teku.extraOptions;
+        ++ (if cfg.consensus.teku.extraOptions != null then cfg.consensus.teku.extraOptions else [ ]);
         allowedPorts = [ 9000 ];
       in
       createService serviceName serviceType execStart parsedEndpoint allowedPorts
@@ -623,12 +623,12 @@ in
             if cfg.addons.mev-boost.enable
             then
               "--payload-builder=true \\\n\t"
-              + "--payload-builder-url=${cfg.addons.mev-boost.endpoint}"
+                + "--payload-builder-url=${cfg.addons.mev-boost.endpoint}"
             else ""
           )
           "--metrics=true"
         ]
-        ++ lib.optional (cfg.consensus.nimbus.extraOptions != null) cfg.consensus.nimbus.extraOptions;
+        ++ (if cfg.consensus.nimbus.extraOptions != null then cfg.consensus.nimbus.extraOptions else [ ]);
         allowedPorts = [ 9000 ];
       in
       createService serviceName serviceType execStart parsedEndpoint allowedPorts

--- a/nixosModules/homestakeros/default.nix
+++ b/nixosModules/homestakeros/default.nix
@@ -317,7 +317,8 @@ in
           "--txpool.api.addr=localhost:9090"
           # ws for ssv
           "--ws"
-        ];
+        ]
+        ++ lib.optional (cfg.execution.erigon.extraOption != null) cfg.execution.erigon.extraOption;
         allowedPorts = [ 30303 30304 42069 ];
       in
       createService serviceName serviceType execStart parsedEndpoint allowedPorts
@@ -358,7 +359,8 @@ in
           "--ws.origins=\"*\""
           "--ws.port=8545"
           "--ws"
-        ];
+        ]
+        ++ lib.optional (cfg.execution.geth.extraOption != null) cfg.execution.geth.extraOption;
         allowedPorts = [ 30303 ];
       in
       createService serviceName serviceType execStart parsedEndpoint allowedPorts
@@ -393,7 +395,8 @@ in
           # ws for ssv
           "--Init.WebSocketsEnabled true"
           "--JsonRpc.WebSocketsPort 8545"
-        ];
+        ]
+        ++ lib.optional (cfg.execution.nethermind.extraOption != null) cfg.execution.nethermind.extraOption;
         allowedPorts = [ 30303 ];
       in
       createService serviceName serviceType execStart parsedEndpoint allowedPorts
@@ -435,7 +438,8 @@ in
           "--rpc-ws-enabled=true"
           "--rpc-ws-host=${parsedEndpoint.addr}"
           "--rpc-ws-port=8546"
-        ];
+        ]
+        ++ lib.optional (cfg.execution.besu.extraOption != null) cfg.execution.besu.extraOption;
         allowedPorts = [ 30303 ];
       in
       createService serviceName serviceType execStart parsedEndpoint allowedPorts
@@ -463,7 +467,8 @@ in
               "https://0xa1559ace749633b997cb3fdacffb890aeebdb0f5a3b6aaa7eeeaf1a38af0a8fe88b9e4b1f61f236d2e64d95733327a62@relay.ultrasound.money"
             ]}"
           "-addr ${parsedEndpoint.addr}:${parsedEndpoint.port}"
-        ];
+        ]
+        ++ lib.optional (cfg.addons.mev-boost.extraOption != null) cfg.addons.mev-boost.extraOption;
         allowedPorts = [ ];
       in
       createService serviceName serviceType execStart parsedEndpoint allowedPorts
@@ -511,7 +516,8 @@ in
           )
           "--metrics"
           "--checkpoint-sync-url \"https://beaconstate.info\""
-        ];
+        ]
+        ++ lib.optional (cfg.consensus.lighthouse.extraOption != null) cfg.consensus.lighthouse.extraOption;
         allowedPorts = [ 9000 9001 ];
       in
       createService serviceName serviceType execStart parsedEndpoint allowedPorts
@@ -553,7 +559,8 @@ in
           "--accept-terms-of-use"
           "--checkpoint-sync-url=https://beaconstate.info"
           "--genesis-beacon-api-url=https://beaconstate.info"
-        ];
+        ]
+        ++ lib.optional (cfg.consensus.prysm.extraOption != null) cfg.consensus.prysm.extraOption;
         allowedPorts = [ 9000 ];
       in
       createService serviceName serviceType execStart parsedEndpoint allowedPorts
@@ -587,7 +594,8 @@ in
             else ""
           )
           "--metrics-enabled=true"
-        ];
+        ]
+        ++ lib.optional (cfg.consensus.teku.extraOption != null) cfg.consensus.teku.extraOption;
         allowedPorts = [ 9000 ];
       in
       createService serviceName serviceType execStart parsedEndpoint allowedPorts
@@ -619,7 +627,8 @@ in
             else ""
           )
           "--metrics=true"
-        ];
+        ]
+        ++ lib.optional (cfg.consensus.nimbus.extraOption != null) cfg.consensus.nimbus.extraOption;
         allowedPorts = [ 9000 ];
       in
       createService serviceName serviceType execStart parsedEndpoint allowedPorts

--- a/nixosModules/homestakeros/default.nix
+++ b/nixosModules/homestakeros/default.nix
@@ -318,7 +318,7 @@ in
           # ws for ssv
           "--ws"
         ]
-        ++ lib.optional (cfg.execution.erigon.extraOption != null) cfg.execution.erigon.extraOption;
+        ++ lib.optional (cfg.execution.erigon.extraOptions != null) cfg.execution.erigon.extraOptions;
         allowedPorts = [ 30303 30304 42069 ];
       in
       createService serviceName serviceType execStart parsedEndpoint allowedPorts
@@ -360,7 +360,7 @@ in
           "--ws.port=8545"
           "--ws"
         ]
-        ++ lib.optional (cfg.execution.geth.extraOption != null) cfg.execution.geth.extraOption;
+        ++ lib.optional (cfg.execution.geth.extraOptions != null) cfg.execution.geth.extraOptions;
         allowedPorts = [ 30303 ];
       in
       createService serviceName serviceType execStart parsedEndpoint allowedPorts
@@ -396,7 +396,7 @@ in
           "--Init.WebSocketsEnabled true"
           "--JsonRpc.WebSocketsPort 8545"
         ]
-        ++ lib.optional (cfg.execution.nethermind.extraOption != null) cfg.execution.nethermind.extraOption;
+        ++ lib.optional (cfg.execution.nethermind.extraOptions != null) cfg.execution.nethermind.extraOptions;
         allowedPorts = [ 30303 ];
       in
       createService serviceName serviceType execStart parsedEndpoint allowedPorts
@@ -439,7 +439,7 @@ in
           "--rpc-ws-host=${parsedEndpoint.addr}"
           "--rpc-ws-port=8546"
         ]
-        ++ lib.optional (cfg.execution.besu.extraOption != null) cfg.execution.besu.extraOption;
+        ++ lib.optional (cfg.execution.besu.extraOptions != null) cfg.execution.besu.extraOptions;
         allowedPorts = [ 30303 ];
       in
       createService serviceName serviceType execStart parsedEndpoint allowedPorts
@@ -468,7 +468,7 @@ in
             ]}"
           "-addr ${parsedEndpoint.addr}:${parsedEndpoint.port}"
         ]
-        ++ lib.optional (cfg.addons.mev-boost.extraOption != null) cfg.addons.mev-boost.extraOption;
+        ++ lib.optional (cfg.addons.mev-boost.extraOptions != null) cfg.addons.mev-boost.extraOptions;
         allowedPorts = [ ];
       in
       createService serviceName serviceType execStart parsedEndpoint allowedPorts
@@ -517,7 +517,7 @@ in
           "--metrics"
           "--checkpoint-sync-url \"https://beaconstate.info\""
         ]
-        ++ lib.optional (cfg.consensus.lighthouse.extraOption != null) cfg.consensus.lighthouse.extraOption;
+        ++ lib.optional (cfg.consensus.lighthouse.extraOptions != null) cfg.consensus.lighthouse.extraOptions;
         allowedPorts = [ 9000 9001 ];
       in
       createService serviceName serviceType execStart parsedEndpoint allowedPorts
@@ -560,7 +560,7 @@ in
           "--checkpoint-sync-url=https://beaconstate.info"
           "--genesis-beacon-api-url=https://beaconstate.info"
         ]
-        ++ lib.optional (cfg.consensus.prysm.extraOption != null) cfg.consensus.prysm.extraOption;
+        ++ lib.optional (cfg.consensus.prysm.extraOptions != null) cfg.consensus.prysm.extraOptions;
         allowedPorts = [ 9000 ];
       in
       createService serviceName serviceType execStart parsedEndpoint allowedPorts
@@ -595,7 +595,7 @@ in
           )
           "--metrics-enabled=true"
         ]
-        ++ lib.optional (cfg.consensus.teku.extraOption != null) cfg.consensus.teku.extraOption;
+        ++ lib.optional (cfg.consensus.teku.extraOptions != null) cfg.consensus.teku.extraOptions;
         allowedPorts = [ 9000 ];
       in
       createService serviceName serviceType execStart parsedEndpoint allowedPorts
@@ -628,7 +628,7 @@ in
           )
           "--metrics=true"
         ]
-        ++ lib.optional (cfg.consensus.nimbus.extraOption != null) cfg.consensus.nimbus.extraOption;
+        ++ lib.optional (cfg.consensus.nimbus.extraOptions != null) cfg.consensus.nimbus.extraOptions;
         allowedPorts = [ 9000 ];
       in
       createService serviceName serviceType execStart parsedEndpoint allowedPorts

--- a/nixosModules/homestakeros/options.nix
+++ b/nixosModules/homestakeros/options.nix
@@ -90,6 +90,12 @@
           description = "Path to the token that ensures safe connection between CL and EL.";
           example = "/var/mnt/erigon/jwt.hex";
         };
+        extraOption = mkOption {
+          type = types.nullOr (types.listOf types.str);
+          default = null;
+          description = "Additional command-line arguments.";
+          example = [ "--some-extra-option=value" ];
+        };
       };
 
       geth = {
@@ -113,6 +119,12 @@
           default = null;
           description = "Path to the token that ensures safe connection between CL and EL.";
           example = "/var/mnt/geth/jwt.hex";
+        };
+        extraOption = mkOption {
+          type = types.nullOr (types.listOf types.str);
+          default = null;
+          description = "Additional command-line arguments.";
+          example = [ "--some-extra-option=value" ];
         };
       };
 
@@ -138,6 +150,12 @@
           description = "Path to the token that ensures safe connection between CL and EL.";
           example = "/var/mnt/nethermind/jwt.hex";
         };
+        extraOption = mkOption {
+          type = types.nullOr (types.listOf types.str);
+          default = null;
+          description = "Additional command-line arguments.";
+          example = [ "--some-extra-option=value" ];
+        };
       };
 
       besu = {
@@ -161,6 +179,12 @@
           default = null;
           description = "Path to the token that ensures safe connection between CL and EL.";
           example = "/var/mnt/besu/jwt.hex";
+        };
+        extraOption = mkOption {
+          type = types.nullOr (types.listOf types.str);
+          default = null;
+          description = "Additional command-line arguments.";
+          example = [ "--some-extra-option=value" ];
         };
       };
     };
@@ -210,6 +234,12 @@
           description = "Path to the token that ensures safe connection between CL and EL.";
           example = "/var/mnt/lighthouse/jwt.hex";
         };
+        extraOption = mkOption {
+          type = types.nullOr (types.listOf types.str);
+          default = null;
+          description = "Additional command-line arguments.";
+          example = [ "--some-extra-option=value" ];
+        };
       };
 
       prysm = {
@@ -246,6 +276,12 @@
           description = "Path to the token that ensures safe connection between CL and EL.";
           example = "/var/mnt/prysm/jwt.hex";
         };
+        extraOption = mkOption {
+          type = types.nullOr (types.listOf types.str);
+          default = null;
+          description = "Additional command-line arguments.";
+          example = [ "--some-extra-option=value" ];
+        };
       };
 
       teku = {
@@ -274,6 +310,12 @@
           default = null;
           description = "Path to the token that ensures safe connection between CL and EL.";
           example = "/var/mnt/teku/jwt.hex";
+        };
+        extraOption = mkOption {
+          type = types.nullOr (types.listOf types.str);
+          default = null;
+          description = "Additional command-line arguments.";
+          example = [ "--some-extra-option=value" ];
         };
       };
 
@@ -304,6 +346,12 @@
           description = "Path to the token that ensures safe connection between CL and EL.";
           example = "/var/mnt/nimbus/jwt.hex";
         };
+        extraOption = mkOption {
+          type = types.nullOr (types.listOf types.str);
+          default = null;
+          description = "Additional command-line arguments.";
+          example = [ "--some-extra-option=value" ];
+        };
       };
     };
 
@@ -324,6 +372,12 @@
           default = "/var/mnt/addons/ssv";
           description = "Path to a persistent directory to store the node's database.";
         };
+        extraOption = mkOption {
+          type = types.nullOr (types.listOf types.str);
+          default = null;
+          description = "Additional command-line arguments.";
+          example = [ "--some-extra-option=value" ];
+        };
       };
       mev-boost = {
         enable = mkOption {
@@ -335,6 +389,12 @@
           type = types.str;
           default = "http://127.0.0.1:18550";
           description = "Listening interface for the MEV-Boost server.";
+        };
+        extraOption = mkOption {
+          type = types.nullOr (types.listOf types.str);
+          default = null;
+          description = "Additional command-line arguments.";
+          example = [ "--some-extra-option=value" ];
         };
       };
     };

--- a/nixosModules/homestakeros/options.nix
+++ b/nixosModules/homestakeros/options.nix
@@ -90,7 +90,7 @@
           description = "Path to the token that ensures safe connection between CL and EL.";
           example = "/var/mnt/erigon/jwt.hex";
         };
-        extraOption = mkOption {
+        extraOptions = mkOption {
           type = types.nullOr (types.listOf types.str);
           default = null;
           description = "Additional command-line arguments.";
@@ -120,7 +120,7 @@
           description = "Path to the token that ensures safe connection between CL and EL.";
           example = "/var/mnt/geth/jwt.hex";
         };
-        extraOption = mkOption {
+        extraOptions = mkOption {
           type = types.nullOr (types.listOf types.str);
           default = null;
           description = "Additional command-line arguments.";
@@ -150,7 +150,7 @@
           description = "Path to the token that ensures safe connection between CL and EL.";
           example = "/var/mnt/nethermind/jwt.hex";
         };
-        extraOption = mkOption {
+        extraOptions = mkOption {
           type = types.nullOr (types.listOf types.str);
           default = null;
           description = "Additional command-line arguments.";
@@ -180,7 +180,7 @@
           description = "Path to the token that ensures safe connection between CL and EL.";
           example = "/var/mnt/besu/jwt.hex";
         };
-        extraOption = mkOption {
+        extraOptions = mkOption {
           type = types.nullOr (types.listOf types.str);
           default = null;
           description = "Additional command-line arguments.";
@@ -234,7 +234,7 @@
           description = "Path to the token that ensures safe connection between CL and EL.";
           example = "/var/mnt/lighthouse/jwt.hex";
         };
-        extraOption = mkOption {
+        extraOptions = mkOption {
           type = types.nullOr (types.listOf types.str);
           default = null;
           description = "Additional command-line arguments.";
@@ -276,7 +276,7 @@
           description = "Path to the token that ensures safe connection between CL and EL.";
           example = "/var/mnt/prysm/jwt.hex";
         };
-        extraOption = mkOption {
+        extraOptions = mkOption {
           type = types.nullOr (types.listOf types.str);
           default = null;
           description = "Additional command-line arguments.";
@@ -311,7 +311,7 @@
           description = "Path to the token that ensures safe connection between CL and EL.";
           example = "/var/mnt/teku/jwt.hex";
         };
-        extraOption = mkOption {
+        extraOptions = mkOption {
           type = types.nullOr (types.listOf types.str);
           default = null;
           description = "Additional command-line arguments.";
@@ -346,7 +346,7 @@
           description = "Path to the token that ensures safe connection between CL and EL.";
           example = "/var/mnt/nimbus/jwt.hex";
         };
-        extraOption = mkOption {
+        extraOptions = mkOption {
           type = types.nullOr (types.listOf types.str);
           default = null;
           description = "Additional command-line arguments.";
@@ -372,7 +372,7 @@
           default = "/var/mnt/addons/ssv";
           description = "Path to a persistent directory to store the node's database.";
         };
-        extraOption = mkOption {
+        extraOptions = mkOption {
           type = types.nullOr (types.listOf types.str);
           default = null;
           description = "Additional command-line arguments.";
@@ -390,7 +390,7 @@
           default = "http://127.0.0.1:18550";
           description = "Listening interface for the MEV-Boost server.";
         };
-        extraOption = mkOption {
+        extraOptions = mkOption {
           type = types.nullOr (types.listOf types.str);
           default = null;
           description = "Additional command-line arguments.";


### PR DESCRIPTION
Added `extraOptions` to clients and addons for manually appending command-line arguments.

Needs to be tested. However, this cannot be used right now since [#49](https://github.com/ponkila/HomestakerOS/pull/49) is more relevant unless this is merged there.

~~Also, found a major issue where the `homestaker` host does not have access to the overlaid packages. Fixed.~~
