### PR TITLE
packages, backend: refactor

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -103,7 +103,14 @@
                 typescript
                 yarn
                 yarn2nix
+                # Cargo test deps
+                nix
+                json2nix
               ];
+              languages.rust = {
+                enable = true;
+                components = [ "cargo" ];
+              };
               env = {
                 NIX_CONFIG = ''
                   accept-flake-config = true
@@ -122,14 +129,25 @@
 
                 INFO
               '';
-              pre-commit = {
-                hooks = {
-                  nixpkgs-fmt.enable = true;
-                  shellcheck.enable = true;
-                  rustfmt.enable = true;
+              pre-commit =
+                let
+                  cargoTomlPath = "./packages/backend/Cargo.toml";
+                in
+                {
+                  hooks =
+                    {
+                      nixpkgs-fmt.enable = true;
+                      shellcheck.enable = true;
+                      rustfmt.enable = true;
+                      cargo-test = {
+                        enable = true;
+                        entry = "cargo test --manifest-path ${cargoTomlPath} --all-features";
+                        files = "\\.rs$";
+                        pass_filenames = false;
+                      };
+                    };
+                  settings.rust.cargoManifestPath = cargoTomlPath;
                 };
-                settings.rust.cargoManifestPath = "./packages/backend/Cargo.toml";
-              };
               # Workaround for https://github.com/cachix/devenv/issues/760
               containers = pkgs.lib.mkForce { };
             };

--- a/flake.nix
+++ b/flake.nix
@@ -103,6 +103,7 @@
                 typescript
                 yarn
                 yarn2nix
+                cargo-tarpaulin
                 # Cargo test deps
                 nix
                 json2nix

--- a/flake.nix
+++ b/flake.nix
@@ -109,7 +109,7 @@
               ];
               languages.rust = {
                 enable = true;
-                components = [ "cargo" ];
+                components = [ "cargo" "clippy" ];
               };
               env = {
                 NIX_CONFIG = ''
@@ -139,6 +139,12 @@
                       nixpkgs-fmt.enable = true;
                       shellcheck.enable = true;
                       rustfmt.enable = true;
+                      pedantic-clippy = {
+                        enable = true;
+                        entry = "cargo clippy --manifest-path ${cargoTomlPath} -- -D clippy::pedantic";
+                        files = "\\.rs$";
+                        pass_filenames = false;
+                      };
                       cargo-test = {
                         enable = true;
                         entry = "cargo test --manifest-path ${cargoTomlPath} --all-features";

--- a/packages/backend/Cargo.lock
+++ b/packages/backend/Cargo.lock
@@ -344,6 +344,7 @@ dependencies = [
  "sha2",
  "tar",
  "tempfile",
+ "uuid",
 ]
 
 [[package]]
@@ -1570,6 +1571,15 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uuid"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0f540e3240398cce6128b64ba83fdbdd86129c16a3aa1a3a252efd66eb3d587"
+dependencies = [
+ "getrandom 0.3.1",
+]
 
 [[package]]
 name = "v_htmlescape"

--- a/packages/backend/Cargo.lock
+++ b/packages/backend/Cargo.lock
@@ -342,7 +342,6 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
- "tar",
  "tempfile",
  "uuid",
 ]
@@ -593,18 +592,6 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
-
-[[package]]
-name = "filetime"
-version = "0.2.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35c0522e981e68cbfa8c3f978441a5f34b30b96e146b33cd3359176b50fe8586"
-dependencies = [
- "cfg-if",
- "libc",
- "libredox",
- "windows-sys 0.59.0",
-]
 
 [[package]]
 name = "flate2"
@@ -942,17 +929,6 @@ name = "libc"
 version = "0.2.169"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
-
-[[package]]
-name = "libredox"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
-dependencies = [
- "bitflags",
- "libc",
- "redox_syscall",
-]
 
 [[package]]
 name = "linux-raw-sys"
@@ -1410,17 +1386,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tar"
-version = "0.4.43"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c65998313f8e17d0d553d28f91a0df93e4dbbbf770279c7bc21ca0f09ea1a1f6"
-dependencies = [
- "filetime",
- "libc",
- "xattr",
-]
-
-[[package]]
 name = "tempfile"
 version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1710,17 +1675,6 @@ name = "writeable"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
-
-[[package]]
-name = "xattr"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e105d177a3871454f754b33bb0ee637ecaaac997446375fd3e5d43a2ed00c909"
-dependencies = [
- "libc",
- "linux-raw-sys",
- "rustix",
-]
 
 [[package]]
 name = "yoke"

--- a/packages/backend/Cargo.lock
+++ b/packages/backend/Cargo.lock
@@ -326,6 +326,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.97"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcfed56ad506cb2c684a14971b8861fdc3baaaae314b9e5f9bb532cbe3ba7a4f"
+
+[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -338,6 +344,7 @@ dependencies = [
  "actix-cors",
  "actix-files",
  "actix-web",
+ "anyhow",
  "clap",
  "serde",
  "serde_json",

--- a/packages/backend/Cargo.toml
+++ b/packages/backend/Cargo.toml
@@ -13,3 +13,4 @@ tempfile = "3.16.0"
 tar = "0.4.43"
 sha2 = "0.10.8"
 serde = { version = "1.0.217", features = ["derive"] }
+uuid = { version = "1.15.1", features = ["v4"] }

--- a/packages/backend/Cargo.toml
+++ b/packages/backend/Cargo.toml
@@ -10,7 +10,6 @@ actix-files = "0.6.6"
 serde_json = "1.0.138"
 clap = "4.5.29"
 tempfile = "3.16.0"
-tar = "0.4.43"
 sha2 = "0.10.8"
 serde = { version = "1.0.217", features = ["derive"] }
 uuid = { version = "1.15.1", features = ["v4"] }

--- a/packages/backend/Cargo.toml
+++ b/packages/backend/Cargo.toml
@@ -13,3 +13,4 @@ tempfile = "3.16.0"
 sha2 = "0.10.8"
 serde = { version = "1.0.217", features = ["derive"] }
 uuid = { version = "1.15.1", features = ["v4"] }
+anyhow = "1.0.97"

--- a/packages/backend/default.nix
+++ b/packages/backend/default.nix
@@ -30,4 +30,7 @@ rustPlatform.buildRustPackage rec {
     wrapProgram $out/bin/${pname} \
       --prefix PATH : ${lib.makeBinPath [ nix json2nix ]}
   '';
+
+  # Tests require access to a /nix/ and a nix daemon; we run them at pre-commit instead
+  doCheck = false;
 }

--- a/packages/backend/src/lib.rs
+++ b/packages/backend/src/lib.rs
@@ -38,17 +38,15 @@ pub fn run_json2nix(json_str: &str) -> Result<String, String> {
 
 /// Writes the default.nix file with the provided json2nix output.
 pub fn write_default_nix(hostname_dir: &Path, json2nix_output: &str) -> std::io::Result<()> {
-    let nix_boilerplate = format!(
-        "{{ pkgs, lib, config, ... }}: {{ homestakeros = {}; }}",
-        json2nix_output
-    );
+    let nix_boilerplate =
+        String::from("{ pkgs, lib, config, ... }: { homestakeros = ") + json2nix_output + "; }";
     let default_nix_path = hostname_dir.join("default.nix");
     fs::write(default_nix_path, nix_boilerplate.as_bytes())
 }
 
 /// Runs the `nix build` command and returns an error string if it fails.
 pub fn run_nix_build(nix_config_dir: &Path, hostname: &str, out_link: &Path) -> Result<(), String> {
-    let nix_config_dir_str = format!("{}", nix_config_dir.display());
+    let nix_config_dir_str = nix_config_dir.display().to_string();
     let build_arg = format!(
         "path:{}#nixosConfigurations.{}.config.system.build.kexecTree",
         nix_config_dir_str, hostname

--- a/packages/backend/src/lib.rs
+++ b/packages/backend/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod schema_types;
 pub mod workspace;
 
+use actix_web::HttpResponse;
 use serde_json::{json, Value};
 use sha2::{Digest, Sha256};
 use std::fs;
@@ -157,4 +158,13 @@ pub fn process_artifacts(
         }
     }
     Ok(artifacts_info)
+}
+
+/// Logs the error and returns a standardized HTTP error response.
+pub fn handle_error<E: std::fmt::Debug>(desc: &str, error: E) -> HttpResponse {
+    println!("{}: {:?}", desc, error);
+    HttpResponse::InternalServerError().json(json!({
+        "status": "error",
+        "message": desc
+    }))
 }

--- a/packages/backend/src/lib.rs
+++ b/packages/backend/src/lib.rs
@@ -57,6 +57,8 @@ pub fn run_nix_build(nix_config_dir: &Path, hostname: &str, out_link: &Path) -> 
         .arg(build_arg)
         .arg("--out-link")
         .arg(out_link)
+        .arg("--extra-experimental-features")
+        .arg("nix-command")
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .output()

--- a/packages/backend/src/lib.rs
+++ b/packages/backend/src/lib.rs
@@ -2,6 +2,7 @@ pub mod schema_types;
 pub mod workspace;
 
 use actix_web::HttpResponse;
+use anyhow::{anyhow, Context, Result};
 use serde_json::{json, Value};
 use sha2::{Digest, Sha256};
 use std::fs;
@@ -14,29 +15,29 @@ use std::process::{Command as StdCommand, Stdio};
 /// # Errors
 ///
 /// Returns an error if spawning the process, writing to its stdin, or waiting for its output fails.
-pub fn run_json2nix(json_str: &str) -> Result<String, String> {
+pub fn run_json2nix(json_str: &str) -> Result<String> {
     let mut child = StdCommand::new("json2nix")
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .spawn()
-        .map_err(|e| format!("Failed to spawn json2nix process: {e:?}"))?;
+        .with_context(|| "Failed to spawn json2nix process")?;
 
     {
         let stdin = child
             .stdin
             .as_mut()
-            .ok_or_else(|| "Failed to open stdin for json2nix".to_string())?;
+            .ok_or_else(|| anyhow!("Failed to open stdin for json2nix"))?;
         stdin
             .write_all(json_str.as_bytes())
-            .map_err(|e| format!("Failed to write to stdin of json2nix: {e:?}"))?;
+            .with_context(|| "Failed to write to stdin of json2nix")?;
     }
     let output = child
         .wait_with_output()
-        .map_err(|e| format!("Command execution failed: {e:?}"))?;
+        .with_context(|| "Command execution failed")?;
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr).to_string();
-        return Err(stderr);
+        return Err(anyhow!(stderr));
     }
     Ok(String::from_utf8_lossy(&output.stdout).to_string())
 }
@@ -53,12 +54,12 @@ pub fn write_default_nix(hostname_dir: &Path, json2nix_output: &str) -> std::io:
     fs::write(default_nix_path, nix_boilerplate.as_bytes())
 }
 
-/// Runs the `nix build` command and returns an error string if it fails.
+/// Runs the `nix build` command and returns an error if it fails.
 ///
 /// # Errors
 ///
 /// Returns an error if executing the command fails or if the build does not succeed.
-pub fn run_nix_build(nix_config_dir: &Path, hostname: &str, out_link: &Path) -> Result<(), String> {
+pub fn run_nix_build(nix_config_dir: &Path, hostname: &str, out_link: &Path) -> Result<()> {
     let nix_config_dir_str = nix_config_dir.display().to_string();
     let build_arg = format!(
         "path:{nix_config_dir_str}#nixosConfigurations.{hostname}.config.system.build.kexecTree"
@@ -73,10 +74,10 @@ pub fn run_nix_build(nix_config_dir: &Path, hostname: &str, out_link: &Path) -> 
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .output()
-        .map_err(|e| format!("Failed to execute nix build: {e:?}"))?;
+        .with_context(|| "Failed to execute nix build")?;
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr).to_string();
-        return Err(stderr);
+        return Err(anyhow!(stderr));
     }
     println!(
         "Nix build stdout: {}",
@@ -116,63 +117,45 @@ pub fn compute_sha256<P: AsRef<Path>>(path: P) -> std::io::Result<String> {
 ///
 /// Returns an error if reading the output directory fails or if a directory entry cannot be processed.
 pub fn process_artifacts(
-    out_link: &std::path::Path,
-    final_build_dir: &std::path::Path,
+    out_link: &Path,
+    final_build_dir: &Path,
     build_id: &str,
     whitelist: &[&str],
-) -> Result<Vec<Value>, String> {
+) -> Result<Vec<Value>> {
     let mut artifacts_info = Vec::new();
-    let entries =
-        fs::read_dir(out_link).map_err(|e| format!("Failed to read out_link dir: {e:?}"))?;
-    for entry in entries {
-        let entry = entry.map_err(|e| format!("Failed to get directory entry: {e:?}"))?;
+    for entry in fs::read_dir(out_link)
+        .with_context(|| format!("Failed to read out_link dir: {out_link:?}"))?
+    {
+        let entry = entry.with_context(|| "Failed to get directory entry")?;
         let path = entry.path();
         if path.is_file() {
-            match path.file_name() {
-                Some(filename_osstr) => {
-                    let filename = filename_osstr.to_string_lossy().to_string();
+            let filename_osstr = path
+                .file_name()
+                .ok_or_else(|| anyhow!("Could not get file_name for {path:?}"))?;
+            let filename = filename_osstr.to_string_lossy().to_string();
 
-                    // Filter by whitelist
-                    if !whitelist.contains(&filename.as_str()) {
-                        println!("Skipping file not in whitelist: {filename}");
-                        continue;
-                    }
-
-                    // Resolve symlinks, and copy real files
-                    match fs::canonicalize(&path) {
-                        Ok(real_path) => {
-                            let dest_file = final_build_dir.join(&filename);
-
-                            if let Err(e) = fs::copy(&real_path, &dest_file) {
-                                eprintln!("Failed to copy {real_path:?} to {dest_file:?}: {e:?}");
-                                continue;
-                            }
-
-                            // Compute SHA256
-                            match compute_sha256(&dest_file) {
-                                Ok(sha) => {
-                                    let download_url =
-                                        "/builds/".to_string() + build_id + "/" + &filename;
-                                    artifacts_info.push(json!({
-                                        "file": filename,
-                                        "sha256": sha,
-                                        "download_url": download_url
-                                    }));
-                                }
-                                Err(e) => {
-                                    eprintln!("Failed to compute sha for {dest_file:?}: {e:?}");
-                                }
-                            }
-                        }
-                        Err(e) => {
-                            eprintln!("Failed to canonicalize {path:?}: {e:?}");
-                        }
-                    }
-                }
-                None => {
-                    eprintln!("Could not get file_name for {path:?}");
-                }
+            // Filter by whitelist
+            if !whitelist.contains(&filename.as_str()) {
+                println!("Skipping file not in whitelist: {filename}");
+                continue;
             }
+
+            // Resolve symlinks, and copy real files
+            let real_path = fs::canonicalize(&path)
+                .with_context(|| format!("Failed to canonicalize {path:?}"))?;
+            let dest_file = final_build_dir.join(&filename);
+            fs::copy(&real_path, &dest_file)
+                .with_context(|| format!("Failed to copy {real_path:?} to {dest_file:?}"))?;
+
+            // Compute SHA256
+            let sha = compute_sha256(&dest_file)
+                .with_context(|| format!("Failed to compute SHA256 for {dest_file:?}"))?;
+            let download_url = format!("/builds/{build_id}/{filename}");
+            artifacts_info.push(json!({
+                "file": filename,
+                "sha256": sha,
+                "download_url": download_url
+            }));
         }
     }
     Ok(artifacts_info)

--- a/packages/backend/src/main.rs
+++ b/packages/backend/src/main.rs
@@ -112,7 +112,7 @@ async fn main() -> std::io::Result<()> {
     let port = matches.get_one::<String>("port").unwrap();
     let base_url = "http://".to_string() + addr + ":" + port;
 
-    println!("Running on: {}", base_url);
+    println!("Running on: {base_url}");
 
     // Create a Workspace singleton.
     let workspace = Workspace::new().expect("Failed to create workspace");

--- a/packages/backend/src/main.rs
+++ b/packages/backend/src/main.rs
@@ -95,21 +95,13 @@ async fn nixos_config(config: web::Json<Config>, data: web::Data<AppState>) -> i
     }
     println!("Nix build completed.");
 
-    // Create /build/<uuid> directory.
+    // Retrieve the build id and pre-created output directory.
     let build_id = &workspace.uuid;
-    let final_build_dir = data.workspace.base_dir.path().join("builds").join(build_id);
-
-    if let Err(e) = fs::create_dir_all(&final_build_dir) {
-        eprintln!("Failed to create final build dir: {:?}", e);
-        return HttpResponse::InternalServerError().json(json!({
-            "status": "error",
-            "message": "Failed to create /builds/<uuid>"
-        }));
-    }
+    let output_dir = workspace.output_dir.clone();
 
     // Copy whitelisted results, and compute their SHA256's.
     let artifacts_info =
-        match process_artifacts(&workspace.out_link, &final_build_dir, build_id, WHITELIST) {
+        match process_artifacts(&workspace.out_link, &output_dir, build_id, WHITELIST) {
             Ok(info) => info,
             Err(e) => {
                 eprintln!("Failed to process artifacts: {}", e);

--- a/packages/backend/src/main.rs
+++ b/packages/backend/src/main.rs
@@ -172,10 +172,8 @@ async fn nixos_config(config: web::Json<Config>, data: web::Data<AppState>) -> i
 
     // Compute a build ID from the two artifact hashes.
     use sha2::{Digest, Sha256};
-    let build_id = format!(
-        "{:x}",
-        Sha256::digest(format!("{}{}", nix_hash, kexec_hash).as_bytes())
-    );
+    let combined_hashes = [nix_hash, kexec_hash].concat();
+    let build_id = format!("{:x}", Sha256::digest(combined_hashes.as_bytes()));
 
     // Move final artifacts into a build-specific subfolder.
     let builds_dir = output_dir.join("builds");
@@ -254,7 +252,7 @@ async fn main() -> std::io::Result<()> {
 
     let addr = matches.get_one::<String>("addr").unwrap();
     let port = matches.get_one::<String>("port").unwrap();
-    let base_url = format!("http://{}:{}", addr, port);
+    let base_url = "http://".to_string() + addr + ":" + port;
 
     println!("Running on: {}", base_url);
     let temp_dir = TempDir::new().expect("Failed to create temporary directory");
@@ -276,7 +274,7 @@ async fn main() -> std::io::Result<()> {
                     .show_files_listing(),
             )
     })
-    .bind(format!("{}:{}", addr, port))?
+    .bind(addr.to_string() + ":" + port)?
     .run()
     .await
 }

--- a/packages/backend/src/workspace.rs
+++ b/packages/backend/src/workspace.rs
@@ -14,6 +14,7 @@ pub struct BuildWorkspace {
     pub nix_config_dir: PathBuf,
     pub hostname_dir: PathBuf,
     pub out_link: PathBuf,
+    pub output_dir: PathBuf,
 }
 
 impl Workspace {
@@ -40,12 +41,17 @@ impl Workspace {
         // Construct a path for the nix build result.
         let out_link = working_dir.join("kexecTree");
 
+        // Create the final build directory.
+        let output_dir = self.base_dir.path().join("builds").join(&build_uuid);
+        fs::create_dir_all(&output_dir)?;
+
         Ok(BuildWorkspace {
             uuid: build_uuid,
             working_dir,
             nix_config_dir,
             hostname_dir,
             out_link,
+            output_dir,
         })
     }
 }

--- a/packages/backend/src/workspace.rs
+++ b/packages/backend/src/workspace.rs
@@ -1,27 +1,34 @@
 use std::fs;
 use std::io;
-use std::path::{Path, PathBuf};
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::path::PathBuf;
+use tempfile::TempDir;
+use uuid::Uuid;
 
-/// Encapsulates the build workspace directories.
+pub struct Workspace {
+    pub base_dir: TempDir,
+}
+
 pub struct BuildWorkspace {
+    pub uuid: String,
     pub working_dir: PathBuf,
     pub nix_config_dir: PathBuf,
     pub hostname_dir: PathBuf,
     pub out_link: PathBuf,
 }
 
-impl BuildWorkspace {
-    /// Creates a new workspace with a unique working directory.
-    pub fn new(output_dir: &Path, hostname: &str) -> io::Result<Self> {
-        let unique_id = match SystemTime::now().duration_since(UNIX_EPOCH) {
-            Ok(duration) => duration.as_nanos().to_string(),
-            Err(_) => "default".to_string(),
-        };
-        let mut dir_name = String::with_capacity("build_work_".len() + unique_id.len());
-        dir_name.push_str("build_work_");
-        dir_name.push_str(&unique_id);
-        let working_dir = output_dir.join(dir_name);
+impl Workspace {
+    /// Create a new top-level workspace.
+    pub fn new() -> io::Result<Self> {
+        let base_dir = TempDir::new()?;
+        fs::create_dir_all(base_dir.path().join("builds"))?;
+        Ok(Workspace { base_dir })
+    }
+
+    /// Create a new build-specific workspace.
+    pub fn new_build_workspace(&self, hostname: &str) -> io::Result<BuildWorkspace> {
+        let build_uuid = Uuid::new_v4().to_string();
+        let dir_name = "build_work_".to_string() + &build_uuid;
+        let working_dir = self.base_dir.path().join(dir_name);
 
         // Create the directories.
         fs::create_dir_all(&working_dir)?;
@@ -34,17 +41,22 @@ impl BuildWorkspace {
         let out_link = working_dir.join("kexecTree");
 
         Ok(BuildWorkspace {
+            uuid: build_uuid,
             working_dir,
             nix_config_dir,
             hostname_dir,
             out_link,
         })
     }
+}
 
-    /// Cleans up the original directories.
-    pub fn cleanup(&self) -> io::Result<()> {
-        fs::remove_dir_all(&self.nix_config_dir)?;
-        fs::remove_file(&self.out_link)?;
-        Ok(())
+/// Automatic partial cleanup
+impl Drop for BuildWorkspace {
+    fn drop(&mut self) {
+        if self.working_dir.exists() {
+            if let Err(e) = fs::remove_dir_all(&self.working_dir) {
+                eprintln!("Warning: Failed to remove working_dir: {:?}", e);
+            }
+        }
     }
 }

--- a/packages/backend/tests/functions.rs
+++ b/packages/backend/tests/functions.rs
@@ -3,60 +3,61 @@ use std::io::Write;
 use tempfile::{tempdir, NamedTempFile};
 
 // Import the helper functions from our library.
-use backend::{compute_sha256, create_tarball, run_json2nix, run_nix_build, write_default_nix};
+use backend::{compute_sha256, create_tarball, write_default_nix};
 
 #[test]
-fn test_compute_sha256() {
+fn test_compute_sha256() -> Result<(), Box<dyn std::error::Error>> {
     // Create a temporary file with known content.
-    let mut temp = NamedTempFile::new().unwrap();
-    write!(temp, "hello world").unwrap();
-    let hash = compute_sha256(temp.path()).unwrap();
+    let mut temp = NamedTempFile::new()?;
+    write!(temp, "hello world")?;
+    let hash = compute_sha256(temp.path())?;
 
     // SHA256("hello world") is:
     let expected = "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9";
     assert_eq!(hash, expected);
+    Ok(())
 }
 
 #[test]
-fn test_create_tarball() {
-    let dir = tempdir().unwrap();
+fn test_create_tarball() -> Result<(), Box<dyn std::error::Error>> {
+    let dir = tempdir()?;
     let file_path = dir.path().join("test.txt");
-    fs::write(&file_path, "content").unwrap();
+    fs::write(&file_path, "content")?;
 
     // Create a separate temporary directory for the tar file.
-    let tar_dir = tempdir().unwrap();
+    let tar_dir = tempdir()?;
     let tar_path = tar_dir.path().join("archive.tar");
 
     // Create a tarball from the source directory.
-    create_tarball(dir.path(), "testdir", &tar_path).unwrap();
+    create_tarball(dir.path(), "testdir", &tar_path)?;
 
     // Open the tarball and verify it contains "test.txt".
-    let tar_file = fs::File::open(&tar_path).unwrap();
+    let tar_file = fs::File::open(&tar_path)?;
     let mut archive = tar::Archive::new(tar_file);
     let mut found = false;
-    for entry in archive.entries().unwrap() {
-        let entry = entry.unwrap();
-        let path = entry.path().unwrap();
+    for entry in archive.entries()? {
+        let entry = entry?;
+        let path = entry.path()?;
         if path.to_string_lossy().contains("test.txt") {
             found = true;
             break;
         }
     }
     assert!(found, "Tarball should contain test.txt");
+    Ok(())
 }
 
 #[test]
-fn test_write_default_nix() {
-    let dir = tempdir().unwrap();
+fn test_write_default_nix() -> Result<(), Box<dyn std::error::Error>> {
+    let dir = tempdir()?;
     let hostname_dir = dir.path().join("hostname");
-    fs::create_dir_all(&hostname_dir).unwrap();
+    fs::create_dir_all(&hostname_dir)?;
     let json2nix_output = "dummy_output";
-    write_default_nix(&hostname_dir, json2nix_output).unwrap();
+    write_default_nix(&hostname_dir, json2nix_output)?;
     let default_nix_path = hostname_dir.join("default.nix");
-    let content = fs::read_to_string(default_nix_path).unwrap();
-    let expected = format!(
-        "{{ pkgs, lib, config, ... }}: {{ homestakeros = {}; }}",
-        json2nix_output
-    );
+    let content = fs::read_to_string(default_nix_path)?;
+    let expected =
+        "{ pkgs, lib, config, ... }: { homestakeros = ".to_string() + json2nix_output + "; }";
     assert_eq!(content, expected);
+    Ok(())
 }

--- a/packages/backend/tests/functions.rs
+++ b/packages/backend/tests/functions.rs
@@ -20,18 +20,22 @@ fn test_compute_sha256() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 fn test_write_default_nix() -> Result<(), Box<dyn std::error::Error>> {
+    // Create a temporary directory and a subdirectory.
     let dir = tempdir()?;
     let hostname_dir = dir.path().join("hostname");
     fs::create_dir_all(&hostname_dir)?;
 
+    // Write default.nix with dummy json2nix output.
     let json2nix_output = "dummy_output";
     write_default_nix(&hostname_dir, json2nix_output)?;
 
+    // Read the generated default.nix content.
     let default_nix_path = hostname_dir.join("default.nix");
     let content = fs::read_to_string(default_nix_path)?;
+
+    // Build expected content and compare.
     let expected =
         "{ pkgs, lib, config, ... }: { homestakeros = ".to_string() + json2nix_output + "; }";
-
     assert_eq!(content, expected);
     Ok(())
 }

--- a/packages/backend/tests/functions.rs
+++ b/packages/backend/tests/functions.rs
@@ -78,3 +78,29 @@ fn test_process_artifacts() -> Result<(), Box<dyn std::error::Error>> {
 
     Ok(())
 }
+
+#[actix_web::test]
+async fn test_handle_error() {
+    // Define a sample error description and a dummy error detail.
+    let desc = "Test error occurred";
+    let dummy_error = "dummy error detail";
+
+    // Call the helper function.
+    let response = backend::handle_error(desc, dummy_error);
+
+    // Verify that the response status code is 500 (Internal Server Error).
+    assert_eq!(
+        response.status(),
+        actix_web::http::StatusCode::INTERNAL_SERVER_ERROR
+    );
+
+    // Extract the body from the response.
+    let body = actix_web::body::to_bytes(response.into_body())
+        .await
+        .unwrap();
+    let json_val: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+    // Verify the JSON content.
+    assert_eq!(json_val["status"], "error");
+    assert_eq!(json_val["message"], desc);
+}

--- a/packages/backend/tests/workspace.rs
+++ b/packages/backend/tests/workspace.rs
@@ -23,6 +23,7 @@ fn test_build_workspace_creation() -> Result<(), Box<dyn std::error::Error>> {
     assert!(build_ws.working_dir.exists());
     assert!(build_ws.nix_config_dir.exists());
     assert!(build_ws.hostname_dir.exists());
+    assert!(build_ws.output_dir.exists());
 
     // For now, out_link path should't exist.
     assert!(!build_ws.out_link.exists());

--- a/packages/backend/tests/workspace.rs
+++ b/packages/backend/tests/workspace.rs
@@ -1,40 +1,51 @@
-use backend::workspace::BuildWorkspace;
-use std::fs;
-use tempfile::TempDir;
+use backend::workspace::Workspace;
+
+#[test]
+fn test_global_workspace_creation() -> Result<(), Box<dyn std::error::Error>> {
+    let workspace = Workspace::new()?;
+
+    // Verify that the workspace directories exists.
+    assert!(workspace.base_dir.path().exists());
+    assert!(workspace.base_dir.path().join("builds").exists());
+
+    Ok(())
+}
 
 #[test]
 fn test_build_workspace_creation() -> Result<(), Box<dyn std::error::Error>> {
-    let temp_dir = TempDir::new()?;
-    let output_dir = temp_dir.path();
+    let workspace = Workspace::new()?;
     let hostname = "testhost";
 
-    let workspace = BuildWorkspace::new(output_dir, hostname)?;
+    // Create the sub-workspace.
+    let build_ws = workspace.new_build_workspace(hostname)?;
 
-    // Verify that the directories exist.
-    assert!(workspace.working_dir.exists());
-    assert!(workspace.nix_config_dir.exists());
-    assert!(workspace.hostname_dir.exists());
+    // Verify that the sub-workspace directories exist.
+    assert!(build_ws.working_dir.exists());
+    assert!(build_ws.nix_config_dir.exists());
+    assert!(build_ws.hostname_dir.exists());
+
+    // For now, out_link path should't exist.
+    assert!(!build_ws.out_link.exists());
 
     Ok(())
 }
 
 #[test]
 fn test_cleanup() -> Result<(), Box<dyn std::error::Error>> {
-    let temp_dir = TempDir::new()?;
-    let output_dir = temp_dir.path();
+    let workspace = Workspace::new()?;
     let hostname = "testhost";
 
-    let workspace = BuildWorkspace::new(output_dir, hostname)?;
+    // Create the sub-workspace
+    let build_ws = workspace.new_build_workspace(hostname)?;
 
-    // Create a dummy file at out_link to simulate a generated file.
-    fs::write(&workspace.out_link, "dummy")?;
+    // Clone the path for later inspection.
+    let working_dir = build_ws.working_dir.clone();
 
-    // Call cleanup to remove the directories.
-    workspace.cleanup()?;
+    // Drop the build workspace to trigger the cleanup.
+    drop(build_ws);
 
-    // Verify that the directories and file have been removed.
-    assert!(!workspace.nix_config_dir.exists());
-    assert!(!workspace.out_link.exists());
+    // Verify that the directorie have been removed.
+    assert!(!working_dir.exists());
 
     Ok(())
 }

--- a/webui/src/Components/ArtifactsList.tsx
+++ b/webui/src/Components/ArtifactsList.tsx
@@ -1,0 +1,51 @@
+import { Box, Heading, VStack, Link, Text, Code, HStack, IconButton, useClipboard } from "@chakra-ui/react";
+import { CopyIcon } from "@chakra-ui/icons";
+
+export interface Artifact {
+  download_url: string;
+  file: string;
+  sha256: string;
+}
+
+const ArtifactsList = ({ artifacts }: { artifacts: Artifact[] }) => {
+  
+  return (
+    <Box>
+      <Heading as="h3" size="md" mb={2}>
+        Artifacts:
+      </Heading>
+      <VStack spacing={3} align="start" width="full">
+        {artifacts.map((artifact, index) => (
+          <ArtifactItem key={index} artifact={artifact} />
+        ))}
+      </VStack>
+    </Box>
+  );
+};
+
+const ArtifactItem = ({ artifact }: { artifact: Artifact }) => {
+  const { onCopy, hasCopied } = useClipboard(artifact.sha256);
+
+  return (
+    <Box p={3} borderWidth={1} borderRadius="md" width="full">
+      <Link href={artifact.download_url} download isExternal fontWeight="bold" color="blue.500">
+        {artifact.file}
+      </Link>
+      <HStack mt={3} spacing={2} align="center" justify="space-between">
+        <Text fontWeight="semibold">SHA256:</Text>
+        <Code fontSize="sm" p={2} borderRadius="md" whiteSpace="nowrap" overflow="hidden" textOverflow="ellipsis">
+        {artifact.sha256}
+        </Code>
+        <IconButton
+          aria-label="Copy SHA256"
+          icon={<CopyIcon />}
+          size="sm"
+          onClick={onCopy}
+        />
+        {hasCopied && <Text fontSize="sm" color="green.500">Copied!</Text>}
+      </HStack>
+    </Box>
+  );
+};
+
+export default ArtifactsList;

--- a/webui/src/Components/ConfigurationForm.tsx
+++ b/webui/src/Components/ConfigurationForm.tsx
@@ -344,6 +344,7 @@ export const ConfigurationForm = () => {
 
     setIsLoading(true);
     setError(null);
+    console.log(props.schema)
     try {
       const response = await fetch(`${backendUrl}/nixosConfig`, {
         method: 'POST',

--- a/webui/src/Components/ConfigurationForm.tsx
+++ b/webui/src/Components/ConfigurationForm.tsx
@@ -344,7 +344,7 @@ export const ConfigurationForm = () => {
 
     setIsLoading(true);
     setError(null);
-    console.log(props.schema)
+    
     try {
       const response = await fetch(`${backendUrl}/nixosConfig`, {
         method: 'POST',
@@ -388,8 +388,8 @@ export const ConfigurationForm = () => {
     joined.push(props.schema)
     joined.push(...props.nodes)
 
-    const options = [<option value="0">New node template</option>]
-    const extOpt = props.nodes.map((v: any, i: number) => (<option key={i} value={i + (options.length)}>{v.localization.hostname}</option>))
+    const options = [<option key={0} value="0">New node template</option>]
+    const extOpt = props.nodes.map((v: any, i: number) => (<option key={i + 1} value={i + (options.length)}>{v.localization.hostname}</option>))
     const jopt = new Array()
     jopt.push(...options)
     jopt.push(...extOpt)
@@ -415,11 +415,7 @@ export const ConfigurationForm = () => {
           </OrderedList>
         </Box>
         <Select value={selectedTemplate} onChange={e => setSelectedTemplate(e.target.value)}>
-          {jopt.map((option, index) => (
-            <option key={index} value={option.value}>
-              {option.label}
-            </option>
-          ))}
+          {jopt}
         </Select>
         {processNode([root], structuredClone(props.schema), chosenJSON)}
         {isLoading && (


### PR DESCRIPTION
Refactoring the backend package, i.e., removing unsafe practices such as `.unwrap()`s and unnecessary use of `format!()` macros, also implementing a workspace singleton to handle workspace creation more elegantly, and using `drop()` instead of a cleanup function. These changes were discussed previously in the review of pull request #71.

In addition to those, I've removed the `nixConfig.tar`, `verify.txt`, and compression from the output, so the backend now outputs only three uncompressed files: the kexec script, kernel, and initrd. Currently, our format also produces iPXE files (`netboot.ipxe` and `variables.ipxe`), but they are filtered out for now, and can be made available for download by adding them to the whitelist.

<details> <summary>Current test results</summary>

         Running tests/functions.rs (target/debug/deps/functions-d7de532171ce6e17)

    running 3 tests
    test test_compute_sha256 ... ok
    test test_write_default_nix ... ok
    test test_process_artifacts ... ok

    test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

         Running tests/json_parsing.rs (target/debug/deps/json_parsing-1f3ce91e4a2b6cc9)

    running 7 tests
    test test_missing_required_fields ... ok
    test test_valid_config ... ok
    test test_missing_nested_required_fields ... ok
    test test_invalid_json ... ok
    test test_unknown_fields ... ok
    test test_unknown_nested_fields ... ok
    test test_invalid_types ... ok

    test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

         Running tests/workspace.rs (target/debug/deps/workspace-e98408f142001c2e)

    running 3 tests
    test test_global_workspace_creation ... ok
    test test_cleanup ... ok
    test test_build_workspace_creation ... ok

    test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
    
</details>

@EeroKokkonen: **Changes are required to the frontend**, since hashes are now included in the HTTP response. Example:

```bash
[I] kari@torgue ~/W/p/H/p/backend (jesse/backend-refactor)> curl -X POST https://buidl.homestakeros.com/nixosConfig -H "Content-Type: application/json" -d '{"localization": {"hostname": "testi"},"ssh": {"authorizedKeys": ["testi"]}}'
{"artifacts":[{"download_url":"/builds/915d919c-e9f9-44d3-877c-ffc850aa4734/initrd.zst","file":"initrd.zst","sha256":"1c528435c866b18c650bdd00d61a931f951441fbc1785bfd8a556b52c3d73784"},{"download_url":"/builds/915d919c-e9f9-44d3-877c-ffc850aa4734/bzImage","file":"bzImage","sha256":"e505b5b5b0e431f6b665f1803ba7fe4c02fd9e16a1b4618868f03477435a4fdc"},{"download_url":"/builds/915d919c-e9f9-44d3-877c-ffc850aa4734/kexec-boot","file":"kexec-boot","sha256":"f38c1c22fafa19c95fa1788ac89c945972e454a8aca9dd77d2f2ad7b9755a2d2"}],"build_id":"915d919c-e9f9-44d3-877c-ffc850aa4734","status":"ok"}
```

Formatted version:
```json
{
  "artifacts": [
    {
      "download_url": "/builds/915d919c-e9f9-44d3-877c-ffc850aa4734/initrd.zst",
      "file": "initrd.zst",
      "sha256": "1c528435c866b18c650bdd00d61a931f951441fbc1785bfd8a556b52c3d73784"
    },
    {
      "download_url": "/builds/915d919c-e9f9-44d3-877c-ffc850aa4734/bzImage",
      "file": "bzImage",
      "sha256": "e505b5b5b0e431f6b665f1803ba7fe4c02fd9e16a1b4618868f03477435a4fdc"
    },
    {
      "download_url": "/builds/915d919c-e9f9-44d3-877c-ffc850aa4734/kexec-boot",
      "file": "kexec-boot",
      "sha256": "f38c1c22fafa19c95fa1788ac89c945972e454a8aca9dd77d2f2ad7b9755a2d2"
    }
  ],
  "build_id": "915d919c-e9f9-44d3-877c-ffc850aa4734",
  "status": "ok"
}
```

**TODO**: After the necessary frontend changes, I will see if we can get more coverage by further separating functions from `main.rs` into `lib.rs` and adding tests for them, address warnings and suggestions by clippy, and also give a second try at adding tests for the functions containing subcommands. Finally, I will address @jhvst's review regarding these changes.