### PR TITLE
packages, backend: output configurations

### DIFF
--- a/packages/backend/Cargo.lock
+++ b/packages/backend/Cargo.lock
@@ -349,6 +349,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "tar",
  "tempfile",
  "uuid",
 ]
@@ -599,6 +600,18 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "filetime"
+version = "0.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35c0522e981e68cbfa8c3f978441a5f34b30b96e146b33cd3359176b50fe8586"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "flate2"
@@ -938,10 +951,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
 
 [[package]]
+name = "libredox"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
+dependencies = [
+ "bitflags",
+ "libc",
+ "redox_syscall",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe7db12097d22ec582439daf8618b8fdd1a7bef6270e9af3b1ebcd30893cf413"
 
 [[package]]
 name = "litemap"
@@ -1230,7 +1260,20 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e56a18552996ac8d29ecc3b190b4fdbb2d91ca4ec396de7bbffaf43f3d637e96"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.9.3",
  "windows-sys 0.59.0",
 ]
 
@@ -1393,6 +1436,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tar"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d863878d212c87a19c1a610eb53bb01fe12951c0501cf5a0d65f724914a667a"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1402,7 +1456,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.3.1",
  "once_cell",
- "rustix",
+ "rustix 0.38.44",
  "windows-sys 0.59.0",
 ]
 
@@ -1682,6 +1736,16 @@ name = "writeable"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
+
+[[package]]
+name = "xattr"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d65cbf2f12c15564212d48f4e3dfb87923d25d611f2aed18f4cb23f0413d89e"
+dependencies = [
+ "libc",
+ "rustix 1.0.3",
+]
 
 [[package]]
 name = "yoke"

--- a/packages/backend/Cargo.toml
+++ b/packages/backend/Cargo.toml
@@ -14,3 +14,4 @@ sha2 = "0.10.8"
 serde = { version = "1.0.217", features = ["derive"] }
 uuid = { version = "1.15.1", features = ["v4"] }
 anyhow = "1.0.97"
+tar = "0.4.43"

--- a/packages/backend/src/static/flake.nix
+++ b/packages/backend/src/static/flake.nix
@@ -42,6 +42,7 @@
                 })
                 hostnames)
             );
+        schema = inputs.homestakeros.schema;
       };
     };
 }

--- a/packages/backend/src/workspace.rs
+++ b/packages/backend/src/workspace.rs
@@ -15,7 +15,6 @@ pub struct Build {
     pub working_dir: PathBuf,
     pub nix_config_dir: PathBuf,
     pub hostname_dir: PathBuf,
-    pub out_link: PathBuf,
     pub output_dir: PathBuf,
 }
 
@@ -53,9 +52,6 @@ impl Workspace {
         fs::create_dir_all(&hostname_dir)
             .with_context(|| format!("Failed to create hostname directory at {hostname_dir:?}"))?;
 
-        // Construct a path for the nix build result.
-        let out_link = working_dir.join("kexecTree");
-
         // Create the final build directory.
         let output_dir = self.base_dir.path().join("builds").join(&build_uuid);
         fs::create_dir_all(&output_dir)
@@ -66,7 +62,6 @@ impl Workspace {
             working_dir,
             nix_config_dir,
             hostname_dir,
-            out_link,
             output_dir,
         })
     }

--- a/packages/backend/tests/workspace.rs
+++ b/packages/backend/tests/workspace.rs
@@ -25,9 +25,6 @@ fn test_build_workspace_creation() -> Result<(), Box<dyn std::error::Error>> {
     assert!(build_ws.hostname_dir.exists());
     assert!(build_ws.output_dir.exists());
 
-    // For now, out_link path should't exist.
-    assert!(!build_ws.out_link.exists());
-
     Ok(())
 }
 


### PR DESCRIPTION
Added `nixConfig.tar` to the build artifacts available for download. It contains a structure such as:
```
.
├── flake.lock
├── flake.nix
├── nixosConfigurations
│   ├── hostnames.json
│   └── testi
│       ├── default.json
│       └── default.nix
└── nixosModules
    └── homestakeros
        └── options.json
```
Work in progress documentation for managing HomestakerOS configurations with Git is available at https://github.com/ponkila/HomestakerOS/blob/3330b577759a7f812557f7803b99463f7b18deca/docs/homestakeros/2.3-git_management.md