### PR TITLE
packages, init-ssv: rewrite

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -96,7 +96,6 @@
           devenv.shells = {
             default = {
               packages = with pkgs; [
-                init-ssv
                 jq
                 nodePackages.eslint
                 nodejs
@@ -119,17 +118,6 @@
                   warn-dirty = false
                 '';
               };
-              enterShell = ''
-                cat <<INFO
-
-                ### HomestakerOS ###
-
-                Available commands:
-
-                  init-ssv  : Generate an SSV operator key pair
-
-                INFO
-              '';
               pre-commit =
                 let
                   cargoTomlPath = "./packages/backend/Cargo.toml";

--- a/packages/init-ssv/default.nix
+++ b/packages/init-ssv/default.nix
@@ -11,6 +11,7 @@ pkgs.stdenv.mkDerivation rec {
 
   buildInputs = with pkgs; [
     jq
+    gnugrep
     ssvnode
   ];
 


### PR DESCRIPTION
Due to some updates, the method of initialization has changed, therefore a rewrite is necessary. This script wouldn't be necessary, but generating the keys with the ssvnode binary seems to be unnecessarily complicated.

Example:
```
[I] kari@torgue ~/W/HomestakerOS (jesse/init-ssv-rewrite)> nix run .#init-ssv -- foobar
saved password to 'password'
generating SSV operator keys...
saved public key to 'ssv_operator_key.pub'
encrypting private key...
saved encrypted private key to 'ssv_operator_key'
generated public key:
LS0tLS1CRUdJTiBSU0EgUFVCTElDIEtFWS0tLS0tCk1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBTUlJQkNnS0NBUUVBdTZPNW9DZkFXOHVVWGNxZWNHam8KWUV3M2Q5UERla0hQeldPNlF4bm1ucmppbXBlZ2QyTnl2WVNlY3k0N1Nya1JlaWFONkt0T1dlRGx4aFI1Y0E2UApBckswYlpoK01wWll1OTBEVmVsbzhwSS9JOUNrWFhzcjN5dTh3U1BYQlpvN1VnT01vcHBQOHhPRS82aHdzbVJWCmtnNlJlZ2JnckpHWnhKQVdrVEpyLzVMWVFKSUswRmRFKytlVEZMZWZmYUhpeGgzaHM3SXg3YkZWaVErNDM2bUEKT0Yzd2pTUlFubUlPeVJNWXcxY0hLY1Q3Rnd1R2IwTkVUcXR4cUhTcndoVVUwWDQ3a3VyVXZXUVFicFNtNHpEawpEeWZsVFJWdlNRTEhSeTV6ZnhydFBYUzR4cHdLVjlBWmo3TGlYQzh2dzhLYSswV3NsREJZTXZYUmdpVjJQWnc2Cm9RSURBUUFCCi0tLS0tRU5EIFJTQSBQVUJMSUMgS0VZLS0tLS0K
```

Work in progress documentation for generating the SSV operator keys: https://github.com/ponkila/HomestakerOS/blob/3ed346cf2c6fa7e3a1b81693548a5e5c4fccb88c/docs/homestakeros/3.2-ssv_node.md#generate-ssv-operator-keys

