### PR TITLE
modules, homestakeros: autogen ssv keys and then some

### DIFF
--- a/docs/homestakeros/3.1-wireguard_vpn.md
+++ b/docs/homestakeros/3.1-wireguard_vpn.md
@@ -24,15 +24,7 @@ These services simplify the process of generating keys, managing peers, and dist
 
 The following steps should be performed directly on your HomestakerOS node:
 
-1. **Install WireGuard tools**:
-
-   ```bash
-   nix-shell -p wireguard-tools
-   ```
-
-   This will start an interactive shell with the necessary command-line tools. Use this shell to run the subsequent commands.
-
-2. **Generate a key pair**:
+1. **Generate a key pair**:
 
    ```bash
    wg genkey | tee clientPrivateKey | wg pubkey > clientPublicKey
@@ -40,7 +32,7 @@ The following steps should be performed directly on your HomestakerOS node:
 
    This generates a cryptographically secure private key and its corresponding public key. WireGuard uses these for authenticated encryption - ensuring only authorized peers can connect to your network while protecting all traffic with strong encryption.
 
-3. **Create and edit the WireGuard configuration file**:
+2. **Create and edit the WireGuard configuration file**:
 
    ```bash
    sudo vim /mnt/secrets/wg0.conf

--- a/docs/homestakeros/3.2-ssv_node.md
+++ b/docs/homestakeros/3.2-ssv_node.md
@@ -80,7 +80,7 @@ After deployment, verify that your SSV node is running correctly:
 2. **Check the service status**:
 
    ```bash
-   systemctl status ssv-autostart.service
+   systemctl status ssv-node.service
    ```
 
    This confirms that the service is properly running without errors.
@@ -88,7 +88,7 @@ After deployment, verify that your SSV node is running correctly:
 3. **View the logs**:
 
    ```bash
-   journalctl -fu ssv-autostart.service
+   journalctl -fu ssv-node.service
    ```
 
    This command displays real-time logs for the SSV service, helping you monitor its operation and troubleshoot any issues.

--- a/docs/homestakeros/3.2-ssv_node.md
+++ b/docs/homestakeros/3.2-ssv_node.md
@@ -13,21 +13,34 @@ Running an SSV node allows you to participate in distributed validator technolog
 
 > **Tip:** 💡 Alternatively, for operator keys generation and registration, you can follow the [SSV Network Instructions](https://ssv-network.gitbook.io/guides/operator/registering-an-operator).
 
-## Fetch SSV Operator Public Key
+## Configure SSV Node in the Web UI
 
-> **Note:** The SSV node is integrated into HomestakerOS by default and does not require explicit enabling. It automatically generates the operator keys if the dataDir is a persistent location and the node will activate once your operator is properly registered on the SSV network.
+SSV-node is integrated into HomestakerOS by default and does not require explicit enabling. The only requirement is ensuring the data directory is set to a persistent location:
+
+> **Important:** If you already have a persistent mount at the SSV-node `dataDir` default, which is `/mnt/addons/ssv`, the directory and keys are already created for you. Skip to the next section. However, if this default path is not suitable for your setup, please continue configuring the paths again. You can remove any automatically generated files at the old location.
+
+1. **Access the configuration tab**:
+   - Go to the 'NixOS config' tab
+   - Select your node from the list or create a new one
+
+2. **Configure SSV-Node**:
+   - In the Add-ons section, find SSV-Node
+   - Set `dataDir` to a **persistent directory** where SSV node will store its operational data and keys
+     > Expected files: ssv_operator_key, ssv_operator_key.pub, and password.
+     > Keys will be generated automatically if missing.
+
+3. **Save and build**:
+   - Click the 'Save' button
+   - Click the `#BUIDL` button to build your updated configuration
+   - Download the boot media and deploy to your node
+
+The build updates the SSV node paths in your HomestakerOS image, and it will automatically start the node once you've completed the registration (checked at 10-minute intervals).
+
+## Fetch SSV Operator Public Key
 
 1. **Locate the SSV data directory**:
 
-   HomestakerOS automatically determines where to store SSV data:
-   - If you have configured mounts, it uses the first available mount point: `<first-mount-point>/ssv`
-   - If no mounts are configured, it defaults to `/mnt/addons/ssv`
-
-     > **Tip:** If this default path is not suitable for your setup:
-     > - Access the Web UI and navigate to the 'NixOS config' tab
-     > - In the Add-ons section, find SSV-Node and re-configure the `dataDir` path
-     > - Rebuild and deploy the update to your node to generate the keys at your preferred location
-     > - Remove any automatically generated files at the old location
+   As mentioned in the last section, the required operator keys are generated automatically at boot if they do not exist. The keys will be generated under the data directory set by the `dataDir` option. SSH into your node and locate this folder.
 
 2. **Retrieve your public key**:
 
@@ -55,7 +68,7 @@ You can do this directly through the HomestakerOS Web UI:
    - Choose whether the operator will be private or public
    - Click the 'Register' button
    - Confirm the transaction in MetaMask
-        > The transaction permanently associates your public key with your Ethereum address on the blockchain.
+     > The transaction permanently associates your public key with your Ethereum address on the blockchain.
 
 3. **Wait for confirmation**:
    - A transaction link will appear in the UI
@@ -75,7 +88,7 @@ After deployment, verify that your SSV node is running correctly:
    curl -s https://api.ssv.network/api/v4/mainnet/operators/public_key/<your_public_key>
    ```
 
-   A registered operator will show complete details in the response
+   A registered operator will show complete details in the response.
 
 2. **Check the service status**:
 

--- a/docs/homestakeros/3.2-ssv_node.md
+++ b/docs/homestakeros/3.2-ssv_node.md
@@ -13,30 +13,29 @@ Running an SSV node allows you to participate in distributed validator technolog
 
 > **Tip:** 💡 Alternatively, for operator keys generation and registration, you can follow the [SSV Network Instructions](https://ssv-network.gitbook.io/guides/operator/registering-an-operator).
 
-## Generate SSV Operator Keys
+## Fetch SSV Operator Public Key
 
-> **Note:** The commands in this section require root privileges. Before proceeding, switch to the root user by running: `sudo su`
+> **Note:** The SSV node is integrated into HomestakerOS by default and does not require explicit enabling. It automatically generates the operator keys if the dataDir is a persistent location and the node will activate once your operator is properly registered on the SSV network.
 
-The following steps should be performed directly on your HomestakerOS node:
+1. **Locate the SSV data directory**:
 
-1. **Create the SSV directory**:
+   HomestakerOS automatically determines where to store SSV data:
+   - If you have configured mounts, it uses the first available mount point: `<first-mount-point>/ssv`
+   - If no mounts are configured, it defaults to `/mnt/addons/ssv`
+
+     > **Tip:** If this default path is not suitable for your setup:
+     > - Access the Web UI and navigate to the 'NixOS config' tab
+     > - In the Add-ons section, find SSV-Node and re-configure the `dataDir` path
+     > - Rebuild and deploy the update to your node to generate the keys at your preferred location
+     > - Remove any automatically generated files at the old location
+
+2. **Retrieve your public key**:
 
    ```bash
-   mkdir -p /mnt/addons/ssv
-   cd /mnt/addons/ssv
+   cat /path/to/ssv_operator_key.pub
    ```
 
-   Creating a dedicated directory keeps your SSV node configuration files organized and separate from other components.
-
-2. **Generate a key pair**:
-
-   ```bash
-   nix run github:ponkila/HomestakerOS#init-ssv --accept-flake-config -- <MY_OPERATOR_PASSWORD>
-   ```
-
-   This command will generate three files: a `password` file containing your password, an encrypted private key in `ssv_operator_key`, and a public key in `ssv_operator_key.pub`. You'll need the public key for registration.
-
-   The key pair is essential for the secure operation of your SSV node. The private key must be kept secure and will be used to sign messages, while the public key identifies your operator on the network.
+   This public key is essential for the operator registration process in the next section. Make sure to copy it exactly as shown.
 
 ## Register as an SSV Operator
 
@@ -58,7 +57,7 @@ You can do this directly through the HomestakerOS Web UI:
    - Confirm the transaction in MetaMask
         > The transaction permanently associates your public key with your Ethereum address on the blockchain.
 
-3. **Verify registration**:
+3. **Wait for confirmation**:
    - A transaction link will appear in the UI
    - Once the transaction is completed, the new operator will appear on SSV.Network
 
@@ -66,39 +65,19 @@ You can do this directly through the HomestakerOS Web UI:
 
 For your SSV node to function properly on the network, it needs to communicate with other nodes. For optimal network connectivity, consider port forwarding TCP port 13001 and UDP port 12001 on your router. However, this is not mandatory if your router supports NAT-PMP or UPnP protocols, which can automatically handle port mapping. Proper network connectivity ensures your SSV node can communicate effectively with the network and participate in its duties.
 
-## Re-Configure SSV Node in the Web UI
-
-> **Important**: If you stored the files exactly at the same paths as the defaults, which are:
-> - dataDir: `/mnt/addons/ssv`
-> - privateKeyFile: `/mnt/addons/ssv/ssv_operator_key`
-> - privateKeyPasswordFile: `/mnt/addons/ssv/password`
->
-> You do not need to re-configure nor rebuild. SSV-node is integrated into HomestakerOS by default and will start automatically when the keys are present (checked at 10-minute intervals). Skip to the "Verifying Your SSV Node" section.
-
-Now that your operator is registered, configure your SSV node:
-
-1. **Access the configuration tab**:
-   - Go to the 'NixOS config' tab
-   - Select your node from the list or create a new one
-
-2. **Configure SSV-Node**:
-   - In the Add-ons section, find SSV-Node
-   - Set `dataDir` to the directory where SSV node will store its operational data
-   - Set `privateKeyFile` to path to your encrypted private key
-   - Set `privateKeyPasswordFile` to path to your password file
-
-3. **Save and build**:
-   - Click the 'Save' button
-   - Click the `#BUIDL` button to build your updated configuration
-   - Download the boot media and deploy to your node
-
-The build updates the SSV node paths in your HomestakerOS image, configuring it to start automatically on boot.
-
 ## Verifying Your SSV Node
 
 After deployment, verify that your SSV node is running correctly:
 
-1. **Check the service status**:
+1. **Verify operator registration**:
+
+   ```bash
+   curl -s https://api.ssv.network/api/v4/mainnet/operators/public_key/<your_public_key>
+   ```
+
+   A registered operator will show complete details in the response
+
+2. **Check the service status**:
 
    ```bash
    systemctl status ssv-autostart.service
@@ -106,7 +85,7 @@ After deployment, verify that your SSV node is running correctly:
 
    This confirms that the service is properly running without errors.
 
-2. **View the logs**:
+3. **View the logs**:
 
    ```bash
    journalctl -fu ssv-autostart.service
@@ -114,7 +93,7 @@ After deployment, verify that your SSV node is running correctly:
 
    This command displays real-time logs for the SSV service, helping you monitor its operation and troubleshoot any issues.
 
-3. **Check operator performance**:
+4. **Check operator performance**:
    - Return to the SSV Explorer and find your operator
    - Verify that it shows as active and is performing duties
 

--- a/docs/homestakeros/3.2-ssv_node.md
+++ b/docs/homestakeros/3.2-ssv_node.md
@@ -15,22 +15,21 @@ Running an SSV node allows you to participate in distributed validator technolog
 
 ## Configure SSV Node in the Web UI
 
-SSV-node is integrated into HomestakerOS by default and does not require explicit enabling. The only requirement is ensuring the data directory is set to a persistent location:
+SSV-node is integrated into HomestakerOS by default and does not require explicit enabling. The only requirement is ensuring the data directory is set to a persistent location where the SSV node will store its operational data and required operator keys, which are automatically generated if missing. The expects files: `ssv_operator_key`, `ssv_operator_key.pub`, and `password`.
 
-> **Important:** If you already have a persistent mount at the SSV-node `dataDir` default, which is `/mnt/addons/ssv`, the directory and keys are already created for you. Skip to the next section. However, if this default path is not suitable for your setup, please continue configuring the paths again. You can remove any automatically generated files at the old location.
+> **Note:** If you already have a persistent mount at the SSV-node `dataDir` default location (`/mnt/addons/ssv`), the directory and keys are already created for you. Skip to the next section. However, if this default path is not suitable for your setup, please continue by reconfiguring the path and updating your node. You can remove any automatically generated files from the old location.
 
-1. **Access the configuration tab**:
-   - Go to the 'NixOS config' tab
-   - Select your node from the list or create a new one
+1. **Access the Web UI**:
+   - Start the backend and access the Web UI as described in [Accessing the Web UI](2.2-accessing_webui.md)
+   - Set the flake URI and load your configurations
 
 2. **Configure SSV-Node**:
-   - In the Add-ons section, find SSV-Node
-   - Set `dataDir` to a **persistent directory** where SSV node will store its operational data and keys
-     > Expected files: ssv_operator_key, ssv_operator_key.pub, and password.
-     > Keys will be generated automatically if missing.
+   - Go to the 'NixOS config' tab and select a node from the list
+   - In the Addons section, set the `dataDir` path to a **persistent location**
+     > **Important:** This must be a path under a defined mount, otherwise the keys will not be generated and the node will not start.
 
 3. **Save and build**:
-   - Click the 'Save' button
+   - Save your configuration
    - Click the `#BUIDL` button to build your updated configuration
    - Download the boot media and deploy to your node
 

--- a/docs/homestakeros/4-reference.md
+++ b/docs/homestakeros/4-reference.md
@@ -34,10 +34,10 @@ Execution layer client options (formerly known as Ethereum 1.0 clients).
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `enable` | Boolean | `false` | Whether to enable Erigon. |
-| `dataDir` | Path | `"/var/mnt/erigon"` | Data directory for the blockchain. |
+| `dataDir` | Path | `"/mnt/erigon"` | Data directory for the blockchain. |
 | `endpoint` | String | `"http://127.0.0.1:8551"` | HTTP-RPC server listening interface of engine API. |
 | `jwtSecretFile` | String | `null` | Path to the token that ensures safe connection between CL and EL.
-Example: `"/var/mnt/erigon/jwt.hex"` |
+Example: `"/mnt/erigon/jwt.hex"` |
 | `extraOptions` | List of Strings | `null` | Additional command-line arguments.
 Example: `["--some-extra-option=value"]` |
 
@@ -46,10 +46,10 @@ Example: `["--some-extra-option=value"]` |
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `enable` | Boolean | `false` | Whether to enable Geth. |
-| `dataDir` | Path | `"/var/mnt/geth"` | Data directory for the blockchain. |
+| `dataDir` | Path | `"/mnt/geth"` | Data directory for the blockchain. |
 | `endpoint` | String | `"http://127.0.0.1:8551"` | HTTP-RPC server listening interface of engine API. |
 | `jwtSecretFile` | String | `null` | Path to the token that ensures safe connection between CL and EL.
-Example: `"/var/mnt/geth/jwt.hex"` |
+Example: `"/mnt/geth/jwt.hex"` |
 | `extraOptions` | List of Strings | `null` | Additional command-line arguments.
 Example: `["--some-extra-option=value"]` |
 
@@ -58,10 +58,10 @@ Example: `["--some-extra-option=value"]` |
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `enable` | Boolean | `false` | Whether to enable Nethermind. |
-| `dataDir` | Path | `"/var/mnt/nethermind"` | Data directory for the blockchain. |
+| `dataDir` | Path | `"/mnt/nethermind"` | Data directory for the blockchain. |
 | `endpoint` | String | `"http://127.0.0.1:8551"` | HTTP-RPC server listening interface of engine API. |
 | `jwtSecretFile` | String | `null` | Path to the token that ensures safe connection between CL and EL.
-Example: `"/var/mnt/nethermind/jwt.hex"` |
+Example: `"/mnt/nethermind/jwt.hex"` |
 | `extraOptions` | List of Strings | `null` | Additional command-line arguments.
 Example: `["--some-extra-option=value"]` |
 
@@ -70,10 +70,10 @@ Example: `["--some-extra-option=value"]` |
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `enable` | Boolean | `false` | Whether to enable Besu. |
-| `dataDir` | Path | `"/var/mnt/besu"` | Data directory for the blockchain. |
+| `dataDir` | Path | `"/mnt/besu"` | Data directory for the blockchain. |
 | `endpoint` | String | `"http://127.0.0.1:8551"` | HTTP-RPC server listening interface of engine API. |
 | `jwtSecretFile` | String | `null` | Path to the token that ensures safe connection between CL and EL.
-Example: `"/var/mnt/besu/jwt.hex"` |
+Example: `"/mnt/besu/jwt.hex"` |
 | `extraOptions` | List of Strings | `null` | Additional command-line arguments.
 Example: `["--some-extra-option=value"]` |
 
@@ -88,11 +88,11 @@ Consensus layer client options (formerly known as Ethereum 2.0 clients).
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `enable` | Boolean | `false` | Whether to enable Lighthouse. |
-| `dataDir` | Path | `"/var/mnt/lighthouse"` | Data directory for the blockchain. |
+| `dataDir` | Path | `"/mnt/lighthouse"` | Data directory for the blockchain. |
 | `endpoint` | String | `"http://127.0.0.1:5052"` | HTTP server listening interface. |
 | `execEndpoint` | String | `"http://127.0.0.1:8551"` | Server endpoint for an execution layer JWT-authenticated HTTP JSON-RPC connection. |
 | `jwtSecretFile` | Path | `null` | Path to the token that ensures safe connection between CL and EL.
-Example: `"/var/mnt/lighthouse/jwt.hex"` |
+Example: `"/mnt/lighthouse/jwt.hex"` |
 | `extraOptions` | List of Strings | `null` | Additional command-line arguments.
 Example: `["--some-extra-option=value"]` |
 | `slasher.enable` | Boolean | `false` | Whether to enable slasher. |
@@ -104,11 +104,11 @@ Example: `["--some-extra-option=value"]` |
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `enable` | Boolean | `false` | Whether to enable Prysm. |
-| `dataDir` | Path | `"/var/mnt/prysm"` | Data directory for the blockchain. |
+| `dataDir` | Path | `"/mnt/prysm"` | Data directory for the blockchain. |
 | `endpoint` | String | `"http://127.0.0.1:3500"` | JSON-HTTP server listening interface. |
 | `execEndpoint` | String | `"http://127.0.0.1:8551"` | Server endpoint for an execution layer JWT-authenticated HTTP JSON-RPC connection. |
 | `jwtSecretFile` | Path | `null` | Path to the token that ensures safe connection between CL and EL.
-Example: `"/var/mnt/prysm/jwt.hex"` |
+Example: `"/mnt/prysm/jwt.hex"` |
 | `extraOptions` | List of Strings | `null` | Additional command-line arguments.
 Example: `["--some-extra-option=value"]` |
 | `slasher.enable` | Boolean | `false` | Whether to enable historical slasher. |
@@ -118,11 +118,11 @@ Example: `["--some-extra-option=value"]` |
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `enable` | Boolean | `false` | Whether to enable Nimbus. |
-| `dataDir` | Path | `"/var/mnt/nimbus"` | Data directory for the blockchain. |
+| `dataDir` | Path | `"/mnt/nimbus"` | Data directory for the blockchain. |
 | `endpoint` | String | `"http://127.0.0.1:5052"` | JSON-HTTP server listening interface. |
 | `execEndpoint` | String | `"http://127.0.0.1:8551"` | Server endpoint for an execution layer JWT-authenticated HTTP JSON-RPC connection. |
 | `jwtSecretFile` | Path | `null` | Path to the token that ensures safe connection between CL and EL.
-Example: `"/var/mnt/nimbus/jwt.hex"` |
+Example: `"/mnt/nimbus/jwt.hex"` |
 | `extraOptions` | List of Strings | `null` | Additional command-line arguments.
 Example: `["--some-extra-option=value"]` |
 
@@ -131,11 +131,11 @@ Example: `["--some-extra-option=value"]` |
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `enable` | Boolean | `false` | Whether to enable Teku. |
-| `dataDir` | Path | `"/var/mnt/teku"` | Data directory for the blockchain. |
+| `dataDir` | Path | `"/mnt/teku"` | Data directory for the blockchain. |
 | `endpoint` | String | `"http://127.0.0.1:5051"` | JSON-HTTP server listening interface. |
 | `execEndpoint` | String | `"http://127.0.0.1:8551"` | Server endpoint for an execution layer JWT-authenticated HTTP JSON-RPC connection. |
 | `jwtSecretFile` | Path | `null` | Path to the token that ensures safe connection between CL and EL.
-Example: `"/var/mnt/teku/jwt.hex"` |
+Example: `"/mnt/teku/jwt.hex"` |
 | `extraOptions` | List of Strings | `null` | Additional command-line arguments.
 Example: `["--some-extra-option=value"]` |
 
@@ -160,7 +160,7 @@ Example: `["--some-extra-option=value"]` |
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `dataDir` | Path | `"/var/mnt/addons/ssv"` | Path to a persistent directory to store the node's database and keys.
+| `dataDir` | Path | `"/mnt/addons/ssv"` | Path to a persistent directory to store the node's database and keys.
 Expected files: ssv_operator_key, ssv_operator_key.pub, and password.
 Keys will be generated automatically if missing. |
 | `extraOptions` | List of Strings | `null` | Additional command-line arguments.
@@ -210,7 +210,7 @@ SSH server configuration for secure remote access to your node.
 | `authorizedKeys` | List of Strings | `[]` | A list of public SSH keys to be added to the user's authorized keys. |
 | `privateKeyFile` | Path | `null` | Path to the Ed25519 SSH host key.
 If absent, the key will be generated automatically.
-Example: `"/var/mnt/secrets/ssh/id_ed25519"` |
+Example: `"/mnt/secrets/ssh/id_ed25519"` |
 
 ## VPN
 
@@ -221,4 +221,4 @@ Virtual Private Network configurations for secure communications.
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `enable` | Boolean | `false` | Whether to enable WireGuard. |
-| `configFile` | Path | `"/var/mnt/secrets/wg0.conf"` | A file path for the wg-quick configuration. |
+| `configFile` | Path | `"/mnt/secrets/wg0.conf"` | A file path for the wg-quick configuration. |

--- a/docs/homestakeros/4-reference.md
+++ b/docs/homestakeros/4-reference.md
@@ -36,9 +36,8 @@ Execution layer client options (formerly known as Ethereum 1.0 clients).
 | `enable` | Boolean | `false` | Whether to enable Erigon. |
 | `dataDir` | Path | `"/mnt/erigon"` | Data directory for the blockchain. |
 | `endpoint` | String | `"http://127.0.0.1:8551"` | HTTP-RPC server listening interface of engine API. |
-| `jwtSecretFile` | String | `null` | Path to the token that ensures safe connection between CL and EL.
-Example: `"/mnt/erigon/jwt.hex"` |
-| `extraOptions` | List of Strings | `null` | Additional command-line arguments.
+| `jwtSecretFile` | String | `"/mnt/secrets/jwt.hex"` | Path to the token that ensures safe connection between CL and EL. |
+| `extraOptions` | List of Strings | `[]` | Additional command-line arguments.
 Example: `["--some-extra-option=value"]` |
 
 ### Geth
@@ -48,9 +47,8 @@ Example: `["--some-extra-option=value"]` |
 | `enable` | Boolean | `false` | Whether to enable Geth. |
 | `dataDir` | Path | `"/mnt/geth"` | Data directory for the blockchain. |
 | `endpoint` | String | `"http://127.0.0.1:8551"` | HTTP-RPC server listening interface of engine API. |
-| `jwtSecretFile` | String | `null` | Path to the token that ensures safe connection between CL and EL.
-Example: `"/mnt/geth/jwt.hex"` |
-| `extraOptions` | List of Strings | `null` | Additional command-line arguments.
+| `jwtSecretFile` | String | `"/mnt/secrets/jwt.hex"` | Path to the token that ensures safe connection between CL and EL. |
+| `extraOptions` | List of Strings | `[]` | Additional command-line arguments.
 Example: `["--some-extra-option=value"]` |
 
 ### Nethermind
@@ -60,9 +58,8 @@ Example: `["--some-extra-option=value"]` |
 | `enable` | Boolean | `false` | Whether to enable Nethermind. |
 | `dataDir` | Path | `"/mnt/nethermind"` | Data directory for the blockchain. |
 | `endpoint` | String | `"http://127.0.0.1:8551"` | HTTP-RPC server listening interface of engine API. |
-| `jwtSecretFile` | String | `null` | Path to the token that ensures safe connection between CL and EL.
-Example: `"/mnt/nethermind/jwt.hex"` |
-| `extraOptions` | List of Strings | `null` | Additional command-line arguments.
+| `jwtSecretFile` | String | `"/mnt/secrets/jwt.hex"` | Path to the token that ensures safe connection between CL and EL. |
+| `extraOptions` | List of Strings | `[]` | Additional command-line arguments.
 Example: `["--some-extra-option=value"]` |
 
 ### Besu
@@ -72,9 +69,8 @@ Example: `["--some-extra-option=value"]` |
 | `enable` | Boolean | `false` | Whether to enable Besu. |
 | `dataDir` | Path | `"/mnt/besu"` | Data directory for the blockchain. |
 | `endpoint` | String | `"http://127.0.0.1:8551"` | HTTP-RPC server listening interface of engine API. |
-| `jwtSecretFile` | String | `null` | Path to the token that ensures safe connection between CL and EL.
-Example: `"/mnt/besu/jwt.hex"` |
-| `extraOptions` | List of Strings | `null` | Additional command-line arguments.
+| `jwtSecretFile` | String | `"/mnt/secrets/jwt.hex"` | Path to the token that ensures safe connection between CL and EL. |
+| `extraOptions` | List of Strings | `[]` | Additional command-line arguments.
 Example: `["--some-extra-option=value"]` |
 
 ## Consensus Clients
@@ -91,9 +87,8 @@ Consensus layer client options (formerly known as Ethereum 2.0 clients).
 | `dataDir` | Path | `"/mnt/lighthouse"` | Data directory for the blockchain. |
 | `endpoint` | String | `"http://127.0.0.1:5052"` | HTTP server listening interface. |
 | `execEndpoint` | String | `"http://127.0.0.1:8551"` | Server endpoint for an execution layer JWT-authenticated HTTP JSON-RPC connection. |
-| `jwtSecretFile` | Path | `null` | Path to the token that ensures safe connection between CL and EL.
-Example: `"/mnt/lighthouse/jwt.hex"` |
-| `extraOptions` | List of Strings | `null` | Additional command-line arguments.
+| `jwtSecretFile` | Path | `"/mnt/secrets/jwt.hex"` | Path to the token that ensures safe connection between CL and EL. |
+| `extraOptions` | List of Strings | `[]` | Additional command-line arguments.
 Example: `["--some-extra-option=value"]` |
 | `slasher.enable` | Boolean | `false` | Whether to enable slasher. |
 | `slasher.historyLength` | Integer | `4096` | Number of epochs to store. |
@@ -107,9 +102,8 @@ Example: `["--some-extra-option=value"]` |
 | `dataDir` | Path | `"/mnt/prysm"` | Data directory for the blockchain. |
 | `endpoint` | String | `"http://127.0.0.1:3500"` | JSON-HTTP server listening interface. |
 | `execEndpoint` | String | `"http://127.0.0.1:8551"` | Server endpoint for an execution layer JWT-authenticated HTTP JSON-RPC connection. |
-| `jwtSecretFile` | Path | `null` | Path to the token that ensures safe connection between CL and EL.
-Example: `"/mnt/prysm/jwt.hex"` |
-| `extraOptions` | List of Strings | `null` | Additional command-line arguments.
+| `jwtSecretFile` | Path | `"/mnt/secrets/jwt.hex"` | Path to the token that ensures safe connection between CL and EL. |
+| `extraOptions` | List of Strings | `[]` | Additional command-line arguments.
 Example: `["--some-extra-option=value"]` |
 | `slasher.enable` | Boolean | `false` | Whether to enable historical slasher. |
 
@@ -121,9 +115,8 @@ Example: `["--some-extra-option=value"]` |
 | `dataDir` | Path | `"/mnt/nimbus"` | Data directory for the blockchain. |
 | `endpoint` | String | `"http://127.0.0.1:5052"` | JSON-HTTP server listening interface. |
 | `execEndpoint` | String | `"http://127.0.0.1:8551"` | Server endpoint for an execution layer JWT-authenticated HTTP JSON-RPC connection. |
-| `jwtSecretFile` | Path | `null` | Path to the token that ensures safe connection between CL and EL.
-Example: `"/mnt/nimbus/jwt.hex"` |
-| `extraOptions` | List of Strings | `null` | Additional command-line arguments.
+| `jwtSecretFile` | Path | `"/mnt/secrets/jwt.hex"` | Path to the token that ensures safe connection between CL and EL. |
+| `extraOptions` | List of Strings | `[]` | Additional command-line arguments.
 Example: `["--some-extra-option=value"]` |
 
 ### Teku
@@ -134,9 +127,8 @@ Example: `["--some-extra-option=value"]` |
 | `dataDir` | Path | `"/mnt/teku"` | Data directory for the blockchain. |
 | `endpoint` | String | `"http://127.0.0.1:5051"` | JSON-HTTP server listening interface. |
 | `execEndpoint` | String | `"http://127.0.0.1:8551"` | Server endpoint for an execution layer JWT-authenticated HTTP JSON-RPC connection. |
-| `jwtSecretFile` | Path | `null` | Path to the token that ensures safe connection between CL and EL.
-Example: `"/mnt/teku/jwt.hex"` |
-| `extraOptions` | List of Strings | `null` | Additional command-line arguments.
+| `jwtSecretFile` | Path | `"/mnt/secrets/jwt.hex"` | Path to the token that ensures safe connection between CL and EL. |
+| `extraOptions` | List of Strings | `[]` | Additional command-line arguments.
 Example: `["--some-extra-option=value"]` |
 
 ## Add-ons
@@ -151,7 +143,7 @@ Additional services and tools to enhance your staking setup.
 |--------|------|---------|-------------|
 | `enable` | Boolean | `false` | Whether to enable MEV-Boost. |
 | `endpoint` | String | `"http://127.0.0.1:18550"` | Listening interface for the MEV-Boost server. |
-| `extraOptions` | List of Strings | `null` | Additional command-line arguments.
+| `extraOptions` | List of Strings | `[]` | Additional command-line arguments.
 Example: `["--some-extra-option=value"]` |
 
 ### SSV-Node
@@ -163,7 +155,7 @@ Example: `["--some-extra-option=value"]` |
 | `dataDir` | Path | `"/mnt/addons/ssv"` | Path to a persistent directory to store the node's database and keys.
 Expected files: ssv_operator_key, ssv_operator_key.pub, and password.
 Keys will be generated automatically if missing. |
-| `extraOptions` | List of Strings | `null` | Additional command-line arguments.
+| `extraOptions` | List of Strings | `[]` | Additional command-line arguments.
 Example: `["--some-extra-option=value"]` |
 
 ## Localization
@@ -174,7 +166,7 @@ Settings related to system localization.
 |--------|------|---------|-------------|
 | `hostname` | String | `"homestaker"` | The name of the machine.
 Must contain only alphanumeric characters, hyphens, or underscores, with a length between 1-63 characters. |
-| `timezone` | String | `null` | The time zone used when displaying times and dates.
+| `timezone` | String | `"UTC"` | The time zone used when displaying times and dates.
 Example: `"America/New_York"` |
 
 ## Mounts
@@ -195,9 +187,9 @@ Each mount entry has the following options:
 | `type` | String | `"auto"` | File system type.
 Example: `"btrfs"` |
 | `wantedBy` | List of Strings | `["multi-user.target"]` | Units that want (i.e. depend on) this unit. |
-| `what` | String | `null` (Required) | Absolute path of device node, file or other resource.
+| `what` | String | (Required) | Absolute path of device node, file or other resource.
 Example: `"/dev/disk/by-label/homestaker"` |
-| `where` | String | `null` (Required) | Absolute path of a directory of the mount point.
+| `where` | String | (Required) | Absolute path of a directory of the mount point.
 Will be created if it doesn't exist.
 Example: `"/mnt/erigon"` |
 
@@ -208,9 +200,8 @@ SSH server configuration for secure remote access to your node.
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `authorizedKeys` | List of Strings | `[]` | A list of public SSH keys to be added to the user's authorized keys. |
-| `privateKeyFile` | Path | `null` | Path to the Ed25519 SSH host key.
-If absent, the key will be generated automatically.
-Example: `"/mnt/secrets/ssh/id_ed25519"` |
+| `privateKeyFile` | Path | `"/mnt/secrets/ssh/id_ed25519"` | Path to the Ed25519 SSH host key.
+If absent, the key will be generated automatically. |
 
 ## VPN
 

--- a/docs/homestakeros/4-reference.md
+++ b/docs/homestakeros/4-reference.md
@@ -160,9 +160,9 @@ Example: `["--some-extra-option=value"]` |
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `dataDir` | Path | `"/var/mnt/addons/ssv"` | Path to a persistent directory to store the node's database. |
-| `privateKeyFile` | Path | `"/var/mnt/addons/ssv/ssv_operator_key"` | Path to the private SSV operator key. |
-| `privateKeyPasswordFile` | Path | `"/var/mnt/addons/ssv/password"` | Path to the password file of SSV operator key. |
+| `dataDir` | Path | `"/var/mnt/addons/ssv"` | Path to a persistent directory to store the node's database and keys.
+Expected files: ssv_operator_key, ssv_operator_key.pub, and password.
+Keys will be generated automatically if missing. |
 | `extraOptions` | List of Strings | `null` | Additional command-line arguments.
 Example: `["--some-extra-option=value"]` |
 

--- a/flake.lock
+++ b/flake.lock
@@ -750,11 +750,11 @@
     },
     "nixpkgs_6": {
       "locked": {
-        "lastModified": 1738574474,
-        "narHash": "sha256-rvyfF49e/k6vkrRTV4ILrWd92W+nmBDfRYZgctOyolQ=",
+        "lastModified": 1734875076,
+        "narHash": "sha256-Pzyb+YNG5u3zP79zoi8HXYMs15Q5dfjDgwCdUI5B0nY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "fecfeb86328381268e29e998ddd3ebc70bbd7f7c",
+        "rev": "1807c2b91223227ad5599d7067a61665c52d1295",
         "type": "github"
       },
       "original": {
@@ -797,11 +797,11 @@
       },
       "locked": {
         "dir": "nixosModules/base",
-        "lastModified": 1735052886,
-        "narHash": "sha256-1KUjXJ3lneHZyFZL+GgBZVfZ4kkhUMZ6gohC4LXURnM=",
+        "lastModified": 1743861196,
+        "narHash": "sha256-DO9LxuY2IttEdJR57Ih/D5P2GUTRZtLuZ6jdbvHg1Uk=",
         "owner": "ponkila",
         "repo": "HomestakerOS",
-        "rev": "a5213786b62b5ac068801d9390ccc8380728b50c",
+        "rev": "09194b91b7dd144ecf63bfea346aee4cb5c16e6c",
         "type": "github"
       },
       "original": {

--- a/nixosModules/base/flake.nix
+++ b/nixosModules/base/flake.nix
@@ -221,8 +221,10 @@
       environment.systemPackages = with pkgs; [
         btrfs-progs
         kexec-tools
+        openssl
         rsync
         vim
+        wireguard-tools
       ];
 
       services.timesyncd.enable = true;

--- a/nixosModules/base/flake.nix
+++ b/nixosModules/base/flake.nix
@@ -225,6 +225,7 @@
         rsync
         vim
         wireguard-tools
+        tree
       ];
 
       services.timesyncd.enable = true;

--- a/nixosModules/homestakeros/default.nix
+++ b/nixosModules/homestakeros/default.nix
@@ -125,7 +125,7 @@ in
       mkIf true {
         services.openssh = {
           enable = true;
-          hostKeys = lib.mkIf (cfg.ssh.privateKeyFile != null) [
+          hostKeys = [
             {
               path = cfg.ssh.privateKeyFile;
               type = "ed25519";
@@ -325,11 +325,7 @@ in
           "--authrpc.vhosts \"*\""
           "--authrpc.port ${parsedEndpoint.port}"
           "--authrpc.addr ${parsedEndpoint.addr}"
-          (
-            if cfg.execution.erigon.jwtSecretFile != null
-            then "--authrpc.jwtsecret ${cfg.execution.erigon.jwtSecretFile}"
-            else ""
-          )
+          "--authrpc.jwtsecret ${cfg.execution.erigon.jwtSecretFile}"
           # json-rpc for interacting
           "--http.addr=${parsedEndpoint.addr}"
           "--http.api=eth,erigon,web3,net,debug,trace,txpool"
@@ -340,7 +336,7 @@ in
           # ws for ssv
           "--ws"
         ]
-        ++ (if cfg.execution.erigon.extraOptions != null then cfg.execution.erigon.extraOptions else [ ]);
+        ++ cfg.execution.erigon.extraOptions;
         allowedPorts = [ 30303 30304 42069 ];
       in
       createService serviceName serviceType execStart parsedEndpoint allowedPorts
@@ -364,11 +360,7 @@ in
           "--authrpc.vhosts \"*\""
           "--authrpc.port ${parsedEndpoint.port}"
           "--authrpc.addr ${parsedEndpoint.addr}"
-          (
-            if cfg.execution.geth.jwtSecretFile != null
-            then "--authrpc.jwtsecret ${cfg.execution.geth.jwtSecretFile}"
-            else ""
-          )
+          "--authrpc.jwtsecret ${cfg.execution.geth.jwtSecretFile}"
           # json-rpc for interacting
           "--http.addr=${parsedEndpoint.addr}"
           "--http.api=eth,web3,net,debug,txpool"
@@ -382,7 +374,7 @@ in
           "--ws.port=8545"
           "--ws"
         ]
-        ++ (if cfg.execution.geth.extraOptions != null then cfg.execution.geth.extraOptions else [ ]);
+        ++ cfg.execution.geth.extraOptions;
         allowedPorts = [ 30303 ];
       in
       createService serviceName serviceType execStart parsedEndpoint allowedPorts
@@ -405,11 +397,7 @@ in
           # auth for consensus client
           "--JsonRpc.EngineHost ${parsedEndpoint.addr}"
           "--JsonRpc.EnginePort ${parsedEndpoint.port}"
-          (
-            if cfg.execution.nethermind.jwtSecretFile != null
-            then "--JsonRpc.JwtSecretFile ${cfg.execution.nethermind.jwtSecretFile}"
-            else ""
-          )
+          "--JsonRpc.JwtSecretFile ${cfg.execution.nethermind.jwtSecretFile}"
           # json-rpc for interacting
           "--JsonRpc.Enabled true"
           "--JsonRpc.Host ${parsedEndpoint.addr}"
@@ -418,7 +406,7 @@ in
           "--Init.WebSocketsEnabled true"
           "--JsonRpc.WebSocketsPort 8545"
         ]
-        ++ (if cfg.execution.nethermind.extraOptions != null then cfg.execution.nethermind.extraOptions else [ ]);
+        ++ cfg.execution.nethermind.extraOptions;
         allowedPorts = [ 30303 ];
       in
       createService serviceName serviceType execStart parsedEndpoint allowedPorts
@@ -443,11 +431,7 @@ in
           "--engine-host-allowlist=\"*\""
           "--engine-rpc-port=${parsedEndpoint.port}"
           "--rpc-http-host=${parsedEndpoint.addr}"
-          (
-            if cfg.execution.besu.jwtSecretFile != null
-            then "--engine-jwt-secret=${cfg.execution.besu.jwtSecretFile}"
-            else ""
-          )
+          "--engine-jwt-secret=${cfg.execution.besu.jwtSecretFile}"
           # json-rpc for interacting
           "--rpc-http-api=ETH,NET,WEB3,TRACE,TXPOOL,DEBUG"
           "--rpc-http-authentication-enabled=false"
@@ -461,7 +445,7 @@ in
           "--rpc-ws-host=${parsedEndpoint.addr}"
           "--rpc-ws-port=8546"
         ]
-        ++ (if cfg.execution.besu.extraOptions != null then cfg.execution.besu.extraOptions else [ ]);
+        ++ cfg.execution.besu.extraOptions;
         allowedPorts = [ 30303 ];
       in
       createService serviceName serviceType execStart parsedEndpoint allowedPorts
@@ -490,7 +474,7 @@ in
             ]}"
           "-addr ${parsedEndpoint.addr}:${parsedEndpoint.port}"
         ]
-        ++ (if cfg.addons.mev-boost.extraOptions != null then cfg.addons.mev-boost.extraOptions else [ ]);
+        ++ cfg.addons.mev-boost.extraOptions;
         allowedPorts = [ ];
       in
       createService serviceName serviceType execStart parsedEndpoint allowedPorts
@@ -514,11 +498,7 @@ in
           "--http-port ${parsedEndpoint.port}"
           "--http-allow-origin \"*\""
           "--execution-endpoint ${cfg.consensus.lighthouse.execEndpoint}"
-          (
-            if cfg.consensus.lighthouse.jwtSecretFile != null
-            then "--execution-jwt ${cfg.consensus.lighthouse.jwtSecretFile}"
-            else ""
-          )
+          "--execution-jwt ${cfg.consensus.lighthouse.jwtSecretFile}"
           "--prune-payloads false"
           (
             if cfg.consensus.lighthouse.slasher.enable
@@ -539,7 +519,7 @@ in
           "--metrics"
           "--checkpoint-sync-url \"https://beaconstate.info\""
         ]
-        ++ (if cfg.consensus.lighthouse.extraOptions != null then cfg.consensus.lighthouse.extraOptions else [ ]);
+        ++ cfg.consensus.lighthouse.extraOptions;
         allowedPorts = [ 9000 9001 ];
       in
       createService serviceName serviceType execStart parsedEndpoint allowedPorts
@@ -561,11 +541,7 @@ in
           "--grpc-gateway-host ${parsedEndpoint.addr}"
           "--grpc-gateway-port ${parsedEndpoint.port}"
           "--execution-endpoint ${cfg.consensus.prysm.execEndpoint}"
-          (
-            if cfg.consensus.prysm.jwtSecretFile != null
-            then "--jwt-secret ${cfg.consensus.prysm.jwtSecretFile}"
-            else ""
-          )
+          "--jwt-secret ${cfg.consensus.prysm.jwtSecretFile}"
           (
             if cfg.addons.mev-boost.enable
             then "--http-mev-relay ${cfg.addons.mev-boost.endpoint}"
@@ -582,7 +558,7 @@ in
           "--checkpoint-sync-url=https://beaconstate.info"
           "--genesis-beacon-api-url=https://beaconstate.info"
         ]
-        ++ (if cfg.consensus.prysm.extraOptions != null then cfg.consensus.prysm.extraOptions else [ ]);
+        ++ cfg.consensus.prysm.extraOptions;
         allowedPorts = [ 9000 ];
       in
       createService serviceName serviceType execStart parsedEndpoint allowedPorts
@@ -605,11 +581,7 @@ in
           "--rest-api-interface=${parsedEndpoint.addr}"
           "--rest-api-host-allowlist=\"*\""
           "--ee-endpoint=${cfg.consensus.teku.execEndpoint}"
-          (
-            if cfg.consensus.teku.jwtSecretFile != null
-            then "--ee-jwt-secret-file=${cfg.consensus.teku.jwtSecretFile}"
-            else ""
-          )
+          "--ee-jwt-secret-file=${cfg.consensus.teku.jwtSecretFile}"
           (
             if cfg.addons.mev-boost.enable
             then "--builder-endpoint=${cfg.addons.mev-boost.endpoint}"
@@ -617,7 +589,7 @@ in
           )
           "--metrics-enabled=true"
         ]
-        ++ (if cfg.consensus.teku.extraOptions != null then cfg.consensus.teku.extraOptions else [ ]);
+        ++ cfg.consensus.teku.extraOptions;
         allowedPorts = [ 9000 ];
       in
       createService serviceName serviceType execStart parsedEndpoint allowedPorts
@@ -650,7 +622,7 @@ in
           )
           "--metrics=true"
         ]
-        ++ (if cfg.consensus.nimbus.extraOptions != null then cfg.consensus.nimbus.extraOptions else [ ]);
+        ++ cfg.consensus.nimbus.extraOptions;
         allowedPorts = [ 9000 ];
       in
       createService serviceName serviceType execStart parsedEndpoint allowedPorts

--- a/nixosModules/homestakeros/default.nix
+++ b/nixosModules/homestakeros/default.nix
@@ -7,7 +7,7 @@ let
   cfg = config.homestakeros;
 in
 {
-  inherit (import ./options.nix { inherit lib pkgs; }) options;
+  inherit (import ./options.nix { inherit lib pkgs cfg; }) options;
 
   config = with lib; let
     # Function to parse a URL into its components
@@ -193,16 +193,12 @@ in
     (
       mkIf
         (
-          cfg.addons.ssv-node.privateKeyFile
-          != null
-          && cfg.addons.ssv-node.privateKeyPasswordFile
-          != null
-          && pkgs.system == "x86_64-linux"
+          pkgs.system == "x86_64-linux"
           && length activeConsensusClients > 0
           && length activeExecutionClients > 0
         )
         {
-          systemd.services.ssv-autostart =
+          systemd.services.ssv-node =
             let
               # TODO: This is a bad way to do this, prevents multiple instances
               executionClient = builtins.elemAt activeExecutionClients 0;
@@ -237,40 +233,60 @@ in
               '';
             in
             {
-              description = "Start the SSV node if the private operator key exists";
-              unitConfig.ConditionPathExists = [
-                "${cfg.addons.ssv-node.privateKeyFile}"
-                "${cfg.addons.ssv-node.privateKeyPasswordFile}"
-              ];
-              # The operator key is defined here, so it does not need to be evaluated
-              script = ''
-                ${pkgs.ssvnode}/bin/ssvnode start-node --config ${ssvConfig}
-              '';
+              description = "Operator node for Secret Shared Validators (SSV)";
+              after = [ "network-online.target" ];
+              wants = [ "network-online.target" ];
               wantedBy = [ "multi-user.target" ];
+
+              script =
+                let
+                  curl = "${pkgs.curl}/bin/curl";
+                  jq = "${pkgs.jq}/bin/jq";
+                in
+                ''
+                  mkdir -p ${cfg.addons.ssv-node.dataDir}
+
+                  # Check if keys exist
+                  if [ ! -f "${cfg.addons.ssv-node.privateKeyFile}" ] || [ ! -f "${cfg.addons.ssv-node.publicKeyFile}" ]; then
+
+                    # Check if dataDir is on tmpfs
+                    FS_TYPE=$(df --output=fstype "${cfg.addons.ssv-node.dataDir}" | tail -n1)
+                    if [[ "$FS_TYPE" =~ ^(tmpfs|overlay|squashfs)$ ]]; then
+                      echo "error: '${cfg.addons.ssv-node.dataDir}' is on a tmpfs; generated keys would be lost after reboot"
+                      exit 1
+                    fi
+
+                    # Generate keys with timestamp as a password
+                    ${pkgs.init-ssv}/bin/init-ssv
+                      --private-key "${cfg.addons.ssv-node.privateKeyFile}" \
+                      --public-key "${cfg.addons.ssv-node.publicKeyFile}" \
+                      --password-file "${cfg.addons.ssv-node.privateKeyPasswordFile}" \
+                      $(date +%s) || exit 1
+                  fi
+
+                  # Start the node if operator is registered
+                  SSV_PUBLIC_KEY=$(cat "${cfg.addons.ssv-node.publicKeyFile}")
+                  if $(${curl} -s "https://api.ssv.network/api/v4/mainnet/operators/public_key/$SSV_PUBLIC_KEY") | ${jq} -e '.data != null' > /dev/null; then
+                    echo "operator is registered, starting ssv node..."
+                    ${pkgs.ssvnode}/bin/ssvnode start-node --config ${ssvConfig}
+                  else
+                    echo "error: operator is not registered yet, exiting"
+                    exit 1
+                  fi
+                '';
               serviceConfig = {
-                Restart = "always";
-                RestartSec = "5s";
                 Type = "simple";
+                Restart = "on-failure";
+                RestartSec = "600s"; # 10 minutes
               };
             };
-          systemd.timers.ssv-autostart = {
-            timerConfig.OnBootSec = "10min";
-            wantedBy = [ "timers.target" ];
-          };
+
           # Firewall
           networking.firewall = {
             allowedTCPPorts = [ 13001 ];
             allowedUDPPorts = [ 12001 ];
           };
         }
-    )
-
-    #################################################################### WIREGUARD
-    # cfg: https://man7.org/linux/man-pages/man8/wg.8.html
-    (
-      mkIf cfg.vpn.wireguard.enable {
-        networking.wg-quick.interfaces.${getVpnInterfaceName "wireguard"}.configFile = cfg.vpn.wireguard.configFile;
-      }
     )
 
     #################################################################### ERIGON

--- a/nixosModules/homestakeros/default.nix
+++ b/nixosModules/homestakeros/default.nix
@@ -276,7 +276,7 @@ in
 
                   # Start the node if operator is registered
                   SSV_PUBLIC_KEY=$(cat "${publicKeyFile}")
-                  if $(${curl} -s "https://api.ssv.network/api/v4/mainnet/operators/public_key/$SSV_PUBLIC_KEY") | ${jq} -e '.data != null' > /dev/null; then
+                  if ${curl} -s "https://api.ssv.network/api/v4/mainnet/operators/public_key/$SSV_PUBLIC_KEY" | ${jq} -e '.data != null' > /dev/null; then
                     echo "operator is registered, starting ssv node..."
                     ${pkgs.ssvnode}/bin/ssvnode start-node --config ${ssvConfig}
                   else

--- a/nixosModules/homestakeros/default.nix
+++ b/nixosModules/homestakeros/default.nix
@@ -289,6 +289,14 @@ in
         }
     )
 
+    #################################################################### WIREGUARD
+    # cfg: https://man7.org/linux/man-pages/man8/wg.8.html
+    (
+      mkIf cfg.vpn.wireguard.enable {
+        networking.wg-quick.interfaces.${getVpnInterfaceName "wireguard"}.configFile = cfg.vpn.wireguard.configFile;
+      }
+    )
+
     #################################################################### ERIGON
     # cli: https://erigon.gitbook.io/erigon/advanced-usage/command-line-options
     # sec: https://erigon.gitbook.io/erigon/basic-usage/default-ports-and-firewalls

--- a/nixosModules/homestakeros/options.nix
+++ b/nixosModules/homestakeros/options.nix
@@ -1,5 +1,4 @@
 { lib
-, cfg
 , ...
 }:
 {
@@ -11,8 +10,8 @@
         description = "The name of the machine.";
       };
       timezone = mkOption {
-        type = types.nullOr types.str;
-        default = null;
+        type = types.str;
+        default = "UTC";
         description = "The time zone used when displaying times and dates.";
         example = "America/New_York";
       };
@@ -40,7 +39,7 @@
           where = mkOption {
             type = types.str;
             description = ''
-              Absolute path of a directory of the mount point. Will be created if it doesn’t exist. (Mandatory)
+              Absolute path of a directory of the mount point. Will be created if it doesn't exist. (Mandatory)
             '';
             example = "/mnt";
           };
@@ -111,10 +110,9 @@
         description = "A list of public SSH keys to be added to the user's authorized keys.";
       };
       privateKeyFile = mkOption {
-        type = types.nullOr types.path;
-        default = null;
+        type = types.path;
+        default = "/mnt/secrets/ssh/id_ed25519";
         description = "Path to the Ed25519 SSH host key. If absent, the key will be generated automatically.";
-        example = "/mnt/secrets/ssh/id_ed25519";
       };
     };
 
@@ -136,14 +134,13 @@
           description = "Data directory for the blockchain.";
         };
         jwtSecretFile = mkOption {
-          type = types.nullOr types.str;
-          default = null;
+          type = types.str;
+          default = "/mnt/secrets/jwt.hex";
           description = "Path to the token that ensures safe connection between CL and EL.";
-          example = "/mnt/erigon/jwt.hex";
         };
         extraOptions = mkOption {
-          type = types.nullOr (types.listOf types.str);
-          default = null;
+          type = types.listOf types.str;
+          default = [ ];
           description = "Additional command-line arguments.";
           example = [ "--some-extra-option=value" ];
         };
@@ -166,14 +163,13 @@
           description = "Data directory for the blockchain.";
         };
         jwtSecretFile = mkOption {
-          type = types.nullOr types.str;
-          default = null;
+          type = types.str;
+          default = "/mnt/secrets/jwt.hex";
           description = "Path to the token that ensures safe connection between CL and EL.";
-          example = "/mnt/geth/jwt.hex";
         };
         extraOptions = mkOption {
-          type = types.nullOr (types.listOf types.str);
-          default = null;
+          type = types.listOf types.str;
+          default = [ ];
           description = "Additional command-line arguments.";
           example = [ "--some-extra-option=value" ];
         };
@@ -196,14 +192,13 @@
           description = "Data directory for the blockchain.";
         };
         jwtSecretFile = mkOption {
-          type = types.nullOr types.str;
-          default = null;
+          type = types.str;
+          default = "/mnt/secrets/jwt.hex";
           description = "Path to the token that ensures safe connection between CL and EL.";
-          example = "/mnt/nethermind/jwt.hex";
         };
         extraOptions = mkOption {
-          type = types.nullOr (types.listOf types.str);
-          default = null;
+          type = types.listOf types.str;
+          default = [ ];
           description = "Additional command-line arguments.";
           example = [ "--some-extra-option=value" ];
         };
@@ -226,14 +221,13 @@
           description = "Data directory for the blockchain.";
         };
         jwtSecretFile = mkOption {
-          type = types.nullOr types.str;
-          default = null;
+          type = types.str;
+          default = "/mnt/secrets/jwt.hex";
           description = "Path to the token that ensures safe connection between CL and EL.";
-          example = "/mnt/besu/jwt.hex";
         };
         extraOptions = mkOption {
-          type = types.nullOr (types.listOf types.str);
-          default = null;
+          type = types.listOf types.str;
+          default = [ ];
           description = "Additional command-line arguments.";
           example = [ "--some-extra-option=value" ];
         };
@@ -280,14 +274,13 @@
           description = "Data directory for the blockchain.";
         };
         jwtSecretFile = mkOption {
-          type = types.nullOr types.path;
-          default = null;
+          type = types.path;
+          default = "/mnt/secrets/jwt.hex";
           description = "Path to the token that ensures safe connection between CL and EL.";
-          example = "/mnt/lighthouse/jwt.hex";
         };
         extraOptions = mkOption {
-          type = types.nullOr (types.listOf types.str);
-          default = null;
+          type = types.listOf types.str;
+          default = [ ];
           description = "Additional command-line arguments.";
           example = [ "--some-extra-option=value" ];
         };
@@ -322,14 +315,13 @@
           description = "Data directory for the blockchain.";
         };
         jwtSecretFile = mkOption {
-          type = types.nullOr types.path;
-          default = null;
+          type = types.path;
+          default = "/mnt/secrets/jwt.hex";
           description = "Path to the token that ensures safe connection between CL and EL.";
-          example = "/mnt/prysm/jwt.hex";
         };
         extraOptions = mkOption {
-          type = types.nullOr (types.listOf types.str);
-          default = null;
+          type = types.listOf types.str;
+          default = [ ];
           description = "Additional command-line arguments.";
           example = [ "--some-extra-option=value" ];
         };
@@ -357,14 +349,13 @@
           description = "Data directory for the blockchain.";
         };
         jwtSecretFile = mkOption {
-          type = types.nullOr types.path;
-          default = null;
+          type = types.path;
+          default = "/mnt/secrets/jwt.hex";
           description = "Path to the token that ensures safe connection between CL and EL.";
-          example = "/mnt/teku/jwt.hex";
         };
         extraOptions = mkOption {
-          type = types.nullOr (types.listOf types.str);
-          default = null;
+          type = types.listOf types.str;
+          default = [ ];
           description = "Additional command-line arguments.";
           example = [ "--some-extra-option=value" ];
         };
@@ -392,14 +383,13 @@
           description = "Data directory for the blockchain.";
         };
         jwtSecretFile = mkOption {
-          type = types.nullOr types.path;
-          default = null;
+          type = types.path;
+          default = "/mnt/secrets/jwt.hex";
           description = "Path to the token that ensures safe connection between CL and EL.";
-          example = "/mnt/nimbus/jwt.hex";
         };
         extraOptions = mkOption {
-          type = types.nullOr (types.listOf types.str);
-          default = null;
+          type = types.listOf types.str;
+          default = [ ];
           description = "Additional command-line arguments.";
           example = [ "--some-extra-option=value" ];
         };
@@ -418,8 +408,8 @@
           '';
         };
         extraOptions = mkOption {
-          type = types.nullOr (types.listOf types.str);
-          default = null;
+          type = types.listOf types.str;
+          default = [ ];
           description = "Additional command-line arguments.";
           example = [ "--some-extra-option=value" ];
         };
@@ -436,8 +426,8 @@
           description = "Listening interface for the MEV-Boost server.";
         };
         extraOptions = mkOption {
-          type = types.nullOr (types.listOf types.str);
-          default = null;
+          type = types.listOf types.str;
+          default = [ ];
           description = "Additional command-line arguments.";
           example = [ "--some-extra-option=value" ];
         };

--- a/nixosModules/homestakeros/options.nix
+++ b/nixosModules/homestakeros/options.nix
@@ -408,21 +408,6 @@
 
     addons = {
       ssv-node = {
-        privateKeyFile = mkOption {
-          type = types.path;
-          default = "/mnt/addons/ssv/ssv_operator_key";
-          description = "Path to the private SSV operator key.";
-        };
-        publicKeyFile = mkOption {
-          type = types.path;
-          default = "/mnt/addons/ssv/ssv_operator_key.pub";
-          description = "Path to the public SSV operator key.";
-        };
-        privateKeyPasswordFile = mkOption {
-          description = "Path to the password file of SSV operator key";
-          type = types.path;
-          default = "/mnt/addons/ssv/password";
-        };
         dataDir = mkOption {
           type = types.path;
           default = "/mnt/addons/ssv";

--- a/nixosModules/homestakeros/options.nix
+++ b/nixosModules/homestakeros/options.nix
@@ -2,17 +2,6 @@
 , cfg
 , ...
 }:
-let
-  # Try to get the first mount's path, fallback to null
-  firstMountPath =
-    let
-      mountNames = lib.attrNames (lib.filterAttrs (name: mount: mount.enable) cfg.mounts);
-      firstMountName = lib.optional (mountNames != [ ]) (builtins.head mountNames);
-    in
-    if firstMountName != [ ]
-    then "${cfg.mounts.${builtins.head firstMountName}.where}"
-    else null;
-in
 {
   options.homestakeros = with lib; {
     localization = {
@@ -421,25 +410,26 @@ in
       ssv-node = {
         privateKeyFile = mkOption {
           type = types.path;
-          default = cfg.addons.ssv-node.dataDir + "/ssv_operator_key";
+          default = "/mnt/addons/ssv/ssv_operator_key";
           description = "Path to the private SSV operator key.";
         };
         publicKeyFile = mkOption {
           type = types.path;
-          default = cfg.addons.ssv-node.dataDir + "/ssv_operator_key.pub";
+          default = "/mnt/addons/ssv/ssv_operator_key.pub";
           description = "Path to the public SSV operator key.";
         };
         privateKeyPasswordFile = mkOption {
           description = "Path to the password file of SSV operator key";
           type = types.path;
-          default = cfg.addons.ssv-node.dataDir + "/password";
+          default = "/mnt/addons/ssv/password";
         };
         dataDir = mkOption {
           type = types.path;
-          default = if firstMountPath != null then firstMountPath else "/mnt/addons/ssv";
+          default = "/mnt/addons/ssv";
           description = ''
-            Path to a persistent directory to store the node's database and keys (if not specified separately).
-            Defaults to the first enabled mount's path + /ssv if any mount exists.
+            Path to a persistent directory to store the node's database and keys.
+            Expected files: ssv_operator_key, ssv_operator_key.pub, and password.
+            Keys will be generated automatically if missing.
           '';
         };
         extraOptions = mkOption {

--- a/packages/init-ssv/init-ssv.sh
+++ b/packages/init-ssv/init-ssv.sh
@@ -1,56 +1,123 @@
 #!/usr/bin/env bash
 # Script to generate SSV operator keys with a password
 
-# Define file paths
-PRIVATE_KEY_PATH="ssv_operator_key"
-PUBLIC_KEY_PATH="ssv_operator_key.pub"
-PASSWORD_PATH="password"
+# Define default file paths
+PRIVATE_KEY_PATH="${PRIVATE_KEY_PATH:-ssv_operator_key}"
+PUBLIC_KEY_PATH="${PUBLIC_KEY_PATH:-ssv_operator_key.pub}"
+PASSWORD_PATH="${PASSWORD_PATH:-password}"
 TEMP_ENCRYPTED_PATH="encrypted_private_key.json"
 
-# Check if password is provided
-if [ "$#" -ne 1 ]; then
-    echo "Usage: init-ssv <password>"
-    exit 1
-fi
+# Display usage information
+display_usage() {
+  cat <<USAGE
+Usage: init-ssv [OPTIONS...] <PASSWORD>
 
-# Save password to file
-echo "$1" > "$PASSWORD_PATH"
-echo "saved password to '$PASSWORD_PATH'"
+Description:
+  Generate SSV operator keys with password encryption.
 
-# Generate keys and capture both stdout and stderr
-echo "generating SSV operator keys..."
-if ! keys_output=$(ssvnode generate-operator-keys 2>&1); then
-    echo "error: failed to generate keys"
-    echo "$keys_output"
-    exit 1
-fi
+Arguments:
+  PASSWORD
+    Password to encrypt the private key (required).
 
-# Extract the public and private keys
-public_key=$(echo "$keys_output" | grep -o '{"pk":.*}' | jq -r '.pk')
-private_key=$(echo "$keys_output" | grep -o '{"sk":.*}' | jq -r '.sk')
+Options:
+  -p, --private-key FILE     Set private key output file (default: $PRIVATE_KEY_PATH)
+  -b, --public-key FILE      Set public key output file (default: $PUBLIC_KEY_PATH)
+  -w, --password-path FILE   Set password file path (default: $PASSWORD_PATH)
+  -h, --help                 Show this help message
+USAGE
+  exit 0
+}
 
-if [ -z "$public_key" ] || [ -z "$private_key" ]; then
+# Main function
+main() {
+  # Parse command line arguments
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -p|--private-key)
+        PRIVATE_KEY_PATH="$2"
+        shift 2
+        ;;
+      -b|--public-key)
+        PUBLIC_KEY_PATH="$2"
+        shift 2
+        ;;
+      -w|--password-file)
+        PASSWORD_PATH="$2"
+        shift 2
+        ;;
+      -h|--help)
+        display_usage
+        ;;
+      -*)
+        echo "error: unknown option: $1"
+        display_usage
+        ;;
+      *)
+        # This should be the password
+        if [[ -z "$PASSWORD" ]]; then
+          PASSWORD="$1"
+          shift
+        else
+          echo "error: only one argument is allowed"
+          display_usage
+        fi
+        ;;
+    esac
+  done
+
+  # Validate required arguments
+  if [[ -z "$PASSWORD" ]]; then
+    echo "error: password must be provided"
+    display_usage
+  fi
+
+  # Ensure output directories exist
+  mkdir -p "$(dirname "$PRIVATE_KEY_PATH")"
+  mkdir -p "$(dirname "$PUBLIC_KEY_PATH")"
+  mkdir -p "$(dirname "$PASSWORD_PATH")"
+
+  # Save password to file
+  echo "$PASSWORD" > "$PASSWORD_PATH"
+  echo "saved password to '$PASSWORD_PATH'"
+
+  # Generate keys and capture both stdout and stderr
+  echo "generating ssv operator keys..."
+  if ! keys_output=$(ssvnode generate-operator-keys 2>&1); then
+      echo "error: failed to generate keys"
+      echo "$keys_output"
+      exit 1
+  fi
+
+  # Extract the public and private keys
+  public_key=$(echo "$keys_output" | grep -o '{"pk":.*}' | jq -r '.pk')
+  private_key=$(echo "$keys_output" | grep -o '{"sk":.*}' | jq -r '.sk')
+
+  if [[ -z "$public_key" ]] || [[ -z "$private_key" ]]; then
     echo "error: could not parse keys from output"
     echo "$keys_output"
     exit 1
-fi
+  fi
 
-# Save public key
-echo "$public_key" > "$PUBLIC_KEY_PATH"
-echo "saved public key to '$PUBLIC_KEY_PATH'"
+  # Save public key
+  echo "$public_key" > "$PUBLIC_KEY_PATH"
+  echo "saved public key to '$PUBLIC_KEY_PATH'"
 
-# Encrypt the private key and capture output
-echo "encrypting private key..."
-if ! encrypt_output=$(echo "$private_key" | ssvnode generate-operator-keys -p "$PASSWORD_PATH" -o /dev/stdin 2>&1) || [ ! -f "$TEMP_ENCRYPTED_PATH" ]; then
-    echo "error: failed to encrypt private key"
-    echo "$encrypt_output"
-    exit 1
-fi
+  # Encrypt the private key and capture output
+  echo "encrypting private key..."
+  if ! encrypt_output=$(echo "$private_key" | ssvnode generate-operator-keys -p "$PASSWORD_PATH" -o /dev/stdin 2>&1) || [ ! -f "$TEMP_ENCRYPTED_PATH" ]; then
+      echo "error: failed to encrypt private key"
+      echo "$encrypt_output"
+      exit 1
+  fi
 
-# Move the encrypted key to the final location
-mv "$TEMP_ENCRYPTED_PATH" "$PRIVATE_KEY_PATH"
-echo "saved encrypted private key to '$PRIVATE_KEY_PATH'"
+  # Move the encrypted key to the final location
+  mv "$TEMP_ENCRYPTED_PATH" "$PRIVATE_KEY_PATH"
+  echo "saved encrypted private key to '$PRIVATE_KEY_PATH'"
 
-# Display the public key
-echo "generated public key:"
-cat "$PUBLIC_KEY_PATH"
+  # Display the public key
+  echo "generated public key:"
+  cat "$PUBLIC_KEY_PATH"
+}
+
+# Run the main function
+main "$@"


### PR DESCRIPTION
Proposal, not tested. Aiming to reduce the threshold for setting up a SSV. 

Keys would be generated automatically at boot if they do not exist, and `addons.ssv-node.dataDir` is a persistent location. The `dataDir` option defaults to the first mount option's "where" path + /ssv subdirectory; if none of the mounts exist, it falls back to /mnt/addons/ssv, however this fallback path would not result in automatic key generation since this location is probably in RAM.

Lastly, the node would only activate when the operator is properly registered. Registration is checked by querying the SSV Network API in 10 minute intervals.